### PR TITLE
disabled buttons if profile is not updated

### DIFF
--- a/src/components/Profile/profile.js
+++ b/src/components/Profile/profile.js
@@ -190,14 +190,13 @@ export default class Profile extends React.Component {
 						<Button
 							className="profile-action-button"
 							style={ this.profileUpdated() ? "green" : "disabled" }
-							onClick= { this.saveProfile }
+							onClick={ this.profileUpdated() ? this.saveProfile : null }
 							text="Save" />
-						<a href="/profile" className="no-style">
-							<Button
+						<Button
 								className="profile-action-button"
 								style={ this.profileUpdated() ? "red" : "disabled" }
+								onClick={ this.profileUpdated() ? () => location.reload() : null }
 								text="Discard" />
-						</a>
 					</div>
 
 					<div className="divider"></div>


### PR DESCRIPTION
Previously the save and discard buttons would always be clickable, even if they were gray.

I added simple logic so that the buttons would have no onclick function if there were no changes to the profile. Now if the buttons are gray, no action will occur when they are clicked.

![screen shot 2018-05-25 at 10 22 28 am](https://user-images.githubusercontent.com/12878275/40557603-90582c5a-6005-11e8-9107-fa9bc5be6548.png)
