### PR TITLE
Fix event cards overflow

### DIFF
--- a/src/components/Events/UserEvents/style.scss
+++ b/src/components/Events/UserEvents/style.scss
@@ -240,6 +240,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  width: 100%;
+  max-width: 100%;
 }
 
 .text {


### PR DESCRIPTION
## Description

- Changed event title so it is truncated by trailing ellipses, ensuring consistent length for every card
- Removed overflow for description section on event cards, ensuring the back button isn't pushed off
- Changed description text formatting so that horizontal scrolling is not needed

## Related Issue

Resolves #177  

## Steps to view & test changes:

- Run the membership portal with the instructions listed in the [acm-membership-portal-deployment ](https://github.com/uclaacm/membership-portal-deployment) repo

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="1512" height="754" alt="image" src="https://github.com/user-attachments/assets/d21bf50c-b061-4dfe-bac7-96d26aa1c6de" />