### PR TITLE
Career Hub and Mobile Views

### DIFF
--- a/src/components/ControlPanel/controlPanel.jsx
+++ b/src/components/ControlPanel/controlPanel.jsx
@@ -1,13 +1,13 @@
-import React from "react";
-import Button from "components/Button";
-import BannerMessage from "components/BannerMessage";
-import EventsModal from "components/Modal/eventsModal";
-import ImagesModal from "components/Modal/imagesModal";
-import AdminsModal from "components/Modal/adminsModal";
-import ReassignModal from "components/Modal/reassignModal";
-import OneClickPasswordModal from "components/Modal/oneClickPasswordModal";
-import ConfirmationModal from "components/Modal/confirmationModal";
-import PropTypes from "prop-types";
+import React from 'react';
+import Button from 'components/Button';
+import BannerMessage from 'components/BannerMessage';
+import EventsModal from 'components/Modal/eventsModal';
+import ImagesModal from 'components/Modal/imagesModal';
+import AdminsModal from 'components/Modal/adminsModal';
+import ReassignModal from 'components/Modal/reassignModal';
+import OneClickPasswordModal from 'components/Modal/oneClickPasswordModal';
+import ConfirmationModal from 'components/Modal/confirmationModal';
+import PropTypes from 'prop-types';
 import ChangeToAdmin from '../Profile/ChangeToAdmin';
 
 
@@ -37,76 +37,82 @@ class ControlPanel extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.oneClickUpdated && nextProps.oneClickUpdateSuccess) {
+      this.closeOneClickPasswordModal();
+    }
+  }
+
   openEventsModal = () => {
-    this.setState(prev => ({ showEventsModal: true }));
+    this.setState({ showEventsModal: true });
   };
 
   closeEventsModal = () => {
-    this.setState(prev => ({ showEventsModal: false }));
+    this.setState({ showEventsModal: false });
   };
 
-  openEventsConfirmationModal = uuid => {
-    this.setState(prev => ({ showEventsConfirmationModal: true, deleteUUID: uuid }));
+  openEventsConfirmationModal = (uuid) => {
+    this.setState({ showEventsConfirmationModal: true, deleteUUID: uuid });
   };
 
   closeEventsConfirmationModal = () => {
-    this.setState(prev => ({ showEventsConfirmationModal: false }));
+    this.setState({ showEventsConfirmationModal: false });
   };
 
   openImagesModal = () => {
-    this.setState(prev => ({ showImagesModal: true }));
+    this.setState({ showImagesModal: true });
   };
 
   closeImagesModal = () => {
-    this.setState(prev => ({ showImagesModal: false }));
+    this.setState({ showImagesModal: false });
   };
 
-  openImagesConfirmationModal = uuid => {
-    this.setState(prev => ({ showImagesConfirmationModal: true, deleteImageUUID: uuid }));
+  openImagesConfirmationModal = (uuid) => {
+    this.setState({ showImagesConfirmationModal: true, deleteImageUUID: uuid });
   };
 
   closeImagesConfirmationModal = () => {
-    this.setState(prev => ({ showImagesConfirmationModal: false }));
+    this.setState({ showImagesConfirmationModal: false });
   };
 
   openAdminsModal = () => {
-    this.setState(prev => ({ showAdminsModal: true }));
+    this.setState({ showAdminsModal: true });
   };
 
   closeAdminsModal = () => {
-    this.setState(prev => ({ showAdminsModal: false }));
+    this.setState({ showAdminsModal: false });
   };
 
   openReassignModal = () => {
-    this.setState(prev => ({ showReassignModal: true }));
+    this.setState({ showReassignModal: true });
   };
 
   closeReassignModal = () => {
-    this.setState(prev => ({ showReassignModal: false }));
+    this.setState({ showReassignModal: false });
   };
 
-  openRemoveAdminConfirmationModal = email => {
-    this.setState(prev => ({ showRemoveAdminConfirmationModal: true, removeEmail: email }));
+  openRemoveAdminConfirmationModal = (email) => {
+    this.setState({ showRemoveAdminConfirmationModal: true, removeEmail: email });
   };
 
   closeRemoveAdminConfirmationModal = () => {
-    this.setState(prev => ({ showRemoveAdminConfirmationModal: false }));
+    this.setState({ showRemoveAdminConfirmationModal: false });
   };
 
-  openReassignAdminConfirmationModal = email => {
-    this.setState(prev => ({ showReassignAdminConfirmationModal: true, reassignEmail: email }));
+  openReassignAdminConfirmationModal = (email) => {
+    this.setState({ showReassignAdminConfirmationModal: true, reassignEmail: email });
   };
 
   closeReassignAdminConfirmationModal = () => {
-    this.setState(prev => ({ showReassignAdminConfirmationModal: false }));
+    this.setState({ showReassignAdminConfirmationModal: false });
   };
 
   openOneClickPasswordModal = () => {
-    this.setState(prev => ({ showOneClickPasswordModal: true }));
+    this.setState({ showOneClickPasswordModal: true });
   };
 
   closeOneClickPasswordModal = () => {
-    this.setState(prev => ({ showOneClickPasswordModal: false }));
+    this.setState({ showOneClickPasswordModal: false });
   };
 
   triggerDeleteEvent = () => {
@@ -137,7 +143,7 @@ class ControlPanel extends React.Component {
     this.closeReassignAdminConfirmationModal();
   };
 
-  triggerAddAdmin = email => {
+  triggerAddAdmin = (email) => {
     const { addAdmin } = this.props;
     addAdmin(email);
   };
@@ -147,14 +153,10 @@ class ControlPanel extends React.Component {
     changeOneClickPassword(oldPassword, newPassword);
   };
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.oneClickUpdated && nextProps.oneClickUpdateSuccess) {
-      this.closeOneClickPasswordModal();
-    }
-  }
-
   render() {
-    const { logout, events, admins, images, isSuperAdmin, userEmail, adminView, toggleAdminView } = this.props;
+    const {
+      logout, events, admins, images, isSuperAdmin, userEmail, adminView, toggleAdminView,
+    } = this.props;
     const {
       showEventsModal,
       showEventsConfirmationModal,
@@ -175,7 +177,7 @@ class ControlPanel extends React.Component {
         <BannerMessage
           showing={this.props.oneClickUpdated}
           success={this.props.oneClickUpdateSuccess}
-          message={this.props.oneClickUpdateSuccess ? "Password updated successfully" : this.props.oneClickError}
+          message={this.props.oneClickUpdateSuccess ? 'Password updated successfully' : this.props.oneClickError}
         />
         <h1 className="DisplayPrimary">Control Panel</h1>
         <div className="form-elem">
@@ -208,7 +210,7 @@ class ControlPanel extends React.Component {
           <Button
             className="control-panel-action-button"
             color="blue"
-            text={adminView ? "Switch to Member View" : "Switch to Admin View"}
+            text={adminView ? 'Switch to Member View' : 'Switch to Admin View'}
             onClick={toggleAdminView}
           />
 
@@ -346,9 +348,17 @@ ControlPanel.propTypes = {
   removeAdmin: PropTypes.func.isRequired,
   reassignAdmin: PropTypes.func.isRequired,
   addAdmin: PropTypes.func.isRequired,
-  events: PropTypes.arrayOf(PropTypes.object).isRequired,
-  admins: PropTypes.arrayOf(PropTypes.object).isRequired,
-  images: PropTypes.arrayOf(PropTypes.object).isRequired,
+  events: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string,
+    title: PropTypes.string,
+  })).isRequired,
+  admins: PropTypes.arrayOf(PropTypes.shape({
+    email: PropTypes.string,
+    firstName: PropTypes.string,
+  })).isRequired,
+  images: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string,
+  })).isRequired,
   isSuperAdmin: PropTypes.bool.isRequired,
   userEmail: PropTypes.string.isRequired,
   changeOneClickPassword: PropTypes.func.isRequired,

--- a/src/components/ControlPanel/index.jsx
+++ b/src/components/ControlPanel/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Topbar from 'containers/topbar';
-import Sidebar from 'containers/sidebar';
 import ControlPanel from './controlPanel';
 
 export default class ControlPanelComponent extends React.Component {
@@ -29,7 +28,7 @@ export default class ControlPanelComponent extends React.Component {
     return (
       <div className="controlpanel">
         <Topbar />
-        {/*<Sidebar />*/}
+        {/* <Sidebar /> */}
         <ControlPanel
           logout={logout}
           userEmail={userEmail}
@@ -57,11 +56,17 @@ export default class ControlPanelComponent extends React.Component {
 ControlPanelComponent.propTypes = {
   logout: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,
-  events: PropTypes.arrayOf(PropTypes.object).isRequired,
+  events: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string,
+  })).isRequired,
   deleteEvent: PropTypes.func.isRequired,
-  images: PropTypes.arrayOf(PropTypes.object).isRequired,
+  images: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string,
+  })).isRequired,
   deleteImage: PropTypes.func.isRequired,
-  admins: PropTypes.arrayOf(PropTypes.object).isRequired,
+  admins: PropTypes.arrayOf(PropTypes.shape({
+    email: PropTypes.string,
+  })).isRequired,
   removeAdmin: PropTypes.func.isRequired,
   addAdmin: PropTypes.func.isRequired,
   reassignAdmin: PropTypes.func.isRequired,

--- a/src/components/Events/AdminEvents/eventMonth.jsx
+++ b/src/components/Events/AdminEvents/eventMonth.jsx
@@ -9,9 +9,11 @@ export default class EventMonth extends React.Component {
     return (
       <div className="event-month">
         <h1 className="Display-2Primary date-month">
-          Events in {month.date.format('MMMM')}
+          Events in
+          {' '}
+          {month.date.format('MMMM')}
         </h1>
-        {month.days.map((day, i) => (
+        {month.days.map(day => (
           <EventDay key={day.date.toString()} day={day} handleEditClick={handleEditClick} />
         ))}
       </div>
@@ -21,8 +23,14 @@ export default class EventMonth extends React.Component {
 
 EventMonth.propTypes = {
   month: PropTypes.shape({
-    date: PropTypes.object,
-    days: PropTypes.array,
+    date: PropTypes.shape({
+      format: PropTypes.func,
+      toString: PropTypes.func,
+    }),
+    days: PropTypes.arrayOf(PropTypes.shape({
+      date: PropTypes.object,
+      events: PropTypes.array,
+    })),
   }).isRequired,
   handleEditClick: PropTypes.func.isRequired,
 };

--- a/src/components/Events/AdminEvents/style.scss
+++ b/src/components/Events/AdminEvents/style.scss
@@ -523,4 +523,72 @@
       border-bottom-left-radius: 0px;
     }
   }
+
+  @media (max-width: 768px) {
+    .main-content {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .top {
+      height: auto;
+      flex-direction: column;
+      width: 100%;
+
+      .cover {
+        width: 100%;
+        height: 200px;
+        border-radius: 4px 4px 0 0;
+      }
+
+      .event-header {
+        display: block;
+        padding: 15px;
+        width: 100%;
+      }
+    }
+
+    .rsvp-section {
+      width: 100%;
+      justify-content: center;
+      margin: 10px 0;
+      padding: 0 15px;
+    }
+
+    .bottom {
+      padding: 15px;
+
+      .info {
+        flex-direction: column;
+        text-align: center;
+
+        .left {
+          border-right: none;
+          border-bottom: 1px solid vars.$secondaryblack;
+          margin: 0 0 10px 0;
+          padding: 0 0 10px 0;
+          width: 100%;
+        }
+
+        .right {
+          width: 100%;
+
+          .description,
+          .location {
+            text-align: center;
+          }
+        }
+      }
+
+      .edit-delete-buttons {
+        width: 100%;
+        text-align: center;
+        margin-top: 15px;
+
+        button {
+          margin: 5px;
+        }
+      }
+    }
+  }
 }

--- a/src/components/Events/style.scss
+++ b/src/components/Events/style.scss
@@ -64,7 +64,7 @@
 
   .checkin-button {
     position: fixed;
-    top: 80px; 
+    top: 80px;
     top: 80px;
     right: 20px;
     z-index: 10;
@@ -76,6 +76,7 @@
 
   @media (max-width: 700px) {
     margin-left: 0px;
+    padding-top: 80px;
 
     .checkin-button {
       top: inherit;

--- a/src/components/Modal/oneClickPasswordModal.jsx
+++ b/src/components/Modal/oneClickPasswordModal.jsx
@@ -1,17 +1,17 @@
-import React from "react";
-import PropTypes from "prop-types";
-import Button from "components/Button";
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from 'components/Button';
 
 export default class OneClickPasswordModal extends React.Component {
   constructor() {
     super();
     this.state = {
-      passwordResetMessage: "",
+      passwordResetMessage: '',
     };
   }
 
-  changePasswordResetMessage = msg => {
-    this.setState(prev => ({ passwordResetMessage: msg }));
+  changePasswordResetMessage = (msg) => {
+    this.setState({ passwordResetMessage: msg });
   };
 
   render() {
@@ -29,7 +29,7 @@ export default class OneClickPasswordModal extends React.Component {
                 name="current-password"
                 placeholder="Current password"
                 id="passwordResetOldPassword"
-                onChange={() => this.changePasswordResetMessage("")}
+                onChange={() => this.changePasswordResetMessage('')}
               />
               <br />
               <br />
@@ -38,7 +38,7 @@ export default class OneClickPasswordModal extends React.Component {
                 name="new-password"
                 placeholder="New password"
                 id="passwordResetNewPassword"
-                onChange={() => this.changePasswordResetMessage("")}
+                onChange={() => this.changePasswordResetMessage('')}
               />
               <br />
               <br />
@@ -47,7 +47,7 @@ export default class OneClickPasswordModal extends React.Component {
                 name="new-password"
                 placeholder="Confirm new password"
                 id="passwordResetConfirmNewPassword"
-                onChange={() => this.changePasswordResetMessage("")}
+                onChange={() => this.changePasswordResetMessage('')}
               />
             </div>
 
@@ -58,13 +58,13 @@ export default class OneClickPasswordModal extends React.Component {
                   color="red"
                   text="Change Password"
                   onClick={() => {
-                    const oldPassword = document.getElementById("passwordResetOldPassword").value;
-                    const newPassword = document.getElementById("passwordResetNewPassword").value;
-                    const confirmNewPassword = document.getElementById("passwordResetConfirmNewPassword").value;
-                    if (oldPassword === "" || newPassword === "" || confirmNewPassword === "") {
-                      this.changePasswordResetMessage("At least one field is empty.");
+                    const oldPassword = document.getElementById('passwordResetOldPassword').value;
+                    const newPassword = document.getElementById('passwordResetNewPassword').value;
+                    const confirmNewPassword = document.getElementById('passwordResetConfirmNewPassword').value;
+                    if (oldPassword === '' || newPassword === '' || confirmNewPassword === '') {
+                      this.changePasswordResetMessage('At least one field is empty.');
                     } else if (newPassword !== confirmNewPassword) {
-                      this.changePasswordResetMessage("New password does not match.");
+                      this.changePasswordResetMessage('New password does not match.');
                     } else {
                       onChange(oldPassword, newPassword);
                     }

--- a/src/components/Profile/CareerLanding.jsx
+++ b/src/components/Profile/CareerLanding.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import './careerLanding.scss';
+
+export default class CareerLanding extends React.Component {
+  calculateCompleteness() {
+    const profile = this.props.profile;
+    let completed = 0;
+    const total = 6;
+
+    if (profile.bio && profile.bio.length >= 50) completed++;
+    if (profile.skills && profile.skills.length >= 3) completed++;
+    if (profile.careerInterests && profile.careerInterests.length >= 2) completed++;
+    if (profile.linkedinUrl || profile.githubUrl) completed++;
+    if (profile.portfolioUrl || profile.personalWebsite) completed++;
+    if (profile.pronouns) completed++;
+
+    return Math.round((completed / total) * 100);
+  }
+
+  render() {
+    const { profile } = this.props;
+    const completeness = this.calculateCompleteness();
+    const isPublic = profile.isProfilePublic !== undefined ? profile.isProfilePublic : true;
+
+    return (
+      <div className="career-landing">
+        <div className="career-landing-header">
+          <h1>Career Hub</h1>
+          <p>Manage your professional profile, explore opportunities, and connect with recruiters</p>
+        </div>
+
+        <div className="career-landing-content">
+          {/* Left Side: Cards */}
+          <div className="career-cards-section">
+            <div className="career-cards">
+              {/* My Profile Card */}
+              <Link to="/profile/career/edit" className="career-card">
+                <div className="career-card-icon">
+                  <i className="fa fa-user" />
+                </div>
+                <div className="career-card-content">
+                  <h2>My Career Profile</h2>
+                  <p>Update your bio, skills, and professional links</p>
+                  <div className="profile-status">
+                    <div className="status-bar">
+                      <div className="status-fill" style={{ width: `${completeness}%` }} />
+                    </div>
+                    <span className="status-text">{completeness}% Complete</span>
+                  </div>
+                  {!isPublic && (
+                    <span className="privacy-badge">
+                      <i className="fa fa-lock" /> Private
+                    </span>
+                  )}
+                </div>
+                <i className="fa fa-chevron-right career-card-arrow" />
+              </Link>
+
+              {/* Recruitment Card */}
+              <div className="career-card disabled">
+                <div className="career-card-icon">
+                  <i className="fa fa-briefcase" />
+                </div>
+                <div className="career-card-content">
+                  <h2>Recruitment</h2>
+                  <p>Connect with companies and explore job opportunities</p>
+                  <span className="coming-soon-badge">Coming Soon</span>
+                </div>
+              </div>
+
+              {/* Committee Applications Card */}
+              <div className="career-card disabled">
+                <div className="career-card-icon">
+                  <i className="fa fa-users" />
+                </div>
+                <div className="career-card-content">
+                  <h2>Committee Applications</h2>
+                  <p>Apply to join ACM committees and officer positions</p>
+                  <span className="coming-soon-badge">Coming Soon</span>
+                </div>
+              </div>
+
+              {/* Resources Card */}
+              <div className="career-card disabled">
+                <div className="career-card-icon">
+                  <i className="fa fa-book" />
+                </div>
+                <div className="career-card-content">
+                  <h2>Career Resources</h2>
+                  <p>Resume templates, interview tips, and career guides</p>
+                  <span className="coming-soon-badge">Coming Soon</span>
+                </div>
+              </div>
+            </div>
+
+            {completeness < 100 && (
+              <div className="career-tips">
+                <h3>
+                  <i className="fa fa-lightbulb" />
+                  {' '}
+                  Complete Your Profile
+                </h3>
+                <p>A complete profile helps recruiters and committee leads find you:</p>
+                <ul>
+                  {(!profile.bio || profile.bio.length < 50) && <li>Add a bio (at least 50 characters)</li>}
+                  {(!profile.skills || profile.skills.length < 3) && <li>List at least 3 skills</li>}
+                  {(!profile.careerInterests || profile.careerInterests.length < 2) && <li>Add 2+ career interests</li>}
+                  {!profile.linkedinUrl && !profile.githubUrl && <li>Add your LinkedIn or GitHub</li>}
+                  {!profile.portfolioUrl && !profile.personalWebsite && <li>Add a portfolio or personal website</li>}
+                  {!profile.pronouns && <li>Add your pronouns</li>}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          {/* Right Side: Profile Preview */}
+          {completeness > 0 && (
+            <div className="profile-preview">
+              <div className="preview-header">
+                <h2>Your Career Profile</h2>
+                <Link to="/profile/career/edit" className="edit-link">
+                  <i className="fa fa-edit" /> Edit
+                </Link>
+              </div>
+              <div className="preview-content">
+                {profile.bio && (
+                  <div className="preview-section">
+                    <h3>Bio</h3>
+                    <p>{profile.bio}</p>
+                  </div>
+                )}
+                
+                {profile.pronouns && (
+                  <div className="preview-section">
+                    <h3>Pronouns</h3>
+                    <p>{profile.pronouns}</p>
+                  </div>
+                )}
+
+                {profile.skills && profile.skills.length > 0 && (
+                  <div className="preview-section">
+                    <h3>Skills</h3>
+                    <div className="tags">
+                      {profile.skills.map((skill, index) => (
+                        <span key={index} className="tag">{skill}</span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {profile.careerInterests && profile.careerInterests.length > 0 && (
+                  <div className="preview-section">
+                    <h3>Career Interests</h3>
+                    <div className="tags">
+                      {profile.careerInterests.map((interest, index) => (
+                        <span key={index} className="tag">{interest}</span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {(profile.linkedinUrl || profile.githubUrl || profile.portfolioUrl || profile.personalWebsite || profile.resumeUrl) && (
+                  <div className="preview-section">
+                    <h3>Links</h3>
+                    <div className="preview-links">
+                      {profile.linkedinUrl && (
+                        <a href={profile.linkedinUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                          <i className="fab fa-linkedin" /> LinkedIn
+                        </a>
+                      )}
+                      {profile.githubUrl && (
+                        <a href={profile.githubUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                          <i className="fab fa-github" /> GitHub
+                        </a>
+                      )}
+                      {profile.portfolioUrl && (
+                        <a href={profile.portfolioUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                          <i className="fa fa-folder" /> Portfolio
+                        </a>
+                      )}
+                      {profile.personalWebsite && (
+                        <a href={profile.personalWebsite} target="_blank" rel="noopener noreferrer" className="preview-link">
+                          <i className="fa fa-globe" /> Website
+                        </a>
+                      )}
+                      {profile.resumeUrl && (
+                        <a href={profile.resumeUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                          <i className="fa fa-file" /> Resume
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+CareerLanding.propTypes = {
+  profile: PropTypes.object,
+};
+
+CareerLanding.defaultProps = {
+  profile: {},
+};

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -106,14 +106,15 @@ export default class CareerProfile extends React.Component {
       skills: this.state.skills,
       careerInterests: this.state.careerInterests,
       isProfilePublic: this.state.isProfilePublic,
+      // Always include URL fields to allow clearing them
+      portfolioUrl: this.state.portfolioUrl,
+      personalWebsite: this.state.personalWebsite,
+      resumeUrl: this.state.resumeUrl,
     };
 
-    // Only include URL fields if they have values
+    // Only include LinkedIn/GitHub if they have values (validator enforces format)
     if (this.state.linkedinUrl) updates.linkedinUrl = this.state.linkedinUrl;
     if (this.state.githubUrl) updates.githubUrl = this.state.githubUrl;
-    if (this.state.portfolioUrl) updates.portfolioUrl = this.state.portfolioUrl;
-    if (this.state.personalWebsite) updates.personalWebsite = this.state.personalWebsite;
-    if (this.state.resumeUrl) updates.resumeUrl = this.state.resumeUrl;
 
     try {
       await this.props.updateCareerProfile(updates);
@@ -159,7 +160,7 @@ export default class CareerProfile extends React.Component {
               {/* Basic Info Section */}
               <div className="form-section">
                 <h2>Basic Information</h2>
-                
+
                 <div className="form-group">
                   <label htmlFor="pronouns">Pronouns</label>
                   <input
@@ -176,7 +177,10 @@ export default class CareerProfile extends React.Component {
                 <div className="form-group">
                   <label htmlFor="bio">
                     Bio
-                    <span className="char-count">{this.state.bio.length}/1000</span>
+                    <span className="char-count">
+                      {this.state.bio.length}
+                      /1000
+                    </span>
                   </label>
                   <textarea
                     id="bio"
@@ -193,7 +197,7 @@ export default class CareerProfile extends React.Component {
               {/* Professional Links Section */}
               <div className="form-section">
                 <h2>Professional Links</h2>
-                
+
                 <div className="form-group">
                   <label htmlFor="linkedinUrl">
                     <i className="fab fa-linkedin" />
@@ -282,10 +286,13 @@ export default class CareerProfile extends React.Component {
               <div className="form-section">
                 <h2>
                   Skills
-                  <span className="count-badge">{this.state.skills.length}/20</span>
+                  <span className="count-badge">
+                    {this.state.skills.length}
+                    /20
+                  </span>
                 </h2>
                 <p className="section-help">Add your technical and soft skills. Press Enter to add each skill.</p>
-                
+
                 <div className="form-group">
                   <input
                     type="text"
@@ -313,10 +320,13 @@ export default class CareerProfile extends React.Component {
               <div className="form-section">
                 <h2>
                   Career Interests
-                  <span className="count-badge">{this.state.careerInterests.length}/20</span>
+                  <span className="count-badge">
+                    {this.state.careerInterests.length}
+                    /20
+                  </span>
                 </h2>
                 <p className="section-help">What career fields or roles interest you? Press Enter to add each interest.</p>
-                
+
                 <div className="form-group">
                   <input
                     type="text"
@@ -343,7 +353,7 @@ export default class CareerProfile extends React.Component {
               {/* Privacy Section */}
               <div className="form-section">
                 <h2>Privacy Settings</h2>
-                
+
                 <div className="toggle-group">
                   <label className="toggle-label">
                     <input
@@ -392,25 +402,40 @@ export default class CareerProfile extends React.Component {
               <div className="progress-bar">
                 <div className="progress-fill" style={{ width: `${completeness}%` }} />
               </div>
-              <p className="progress-text">{completeness}% Complete</p>
+              <p className="progress-text">
+                {completeness}
+                % Complete
+              </p>
               <ul className="completeness-checklist">
                 <li className={this.state.bio && this.state.bio.length >= 50 ? 'complete' : ''}>
-                  {this.state.bio && this.state.bio.length >= 50 ? '✓' : '○'} Bio (50+ characters)
+                  {this.state.bio && this.state.bio.length >= 50 ? '✓' : '○'}
+                  {' '}
+                  Bio (50+ characters)
                 </li>
                 <li className={this.state.skills.length >= 3 ? 'complete' : ''}>
-                  {this.state.skills.length >= 3 ? '✓' : '○'} At least 3 skills
+                  {this.state.skills.length >= 3 ? '✓' : '○'}
+                  {' '}
+                  At least 3 skills
                 </li>
                 <li className={this.state.careerInterests.length >= 2 ? 'complete' : ''}>
-                  {this.state.careerInterests.length >= 2 ? '✓' : '○'} At least 2 career interests
+                  {this.state.careerInterests.length >= 2 ? '✓' : '○'}
+                  {' '}
+                  At least 2 career interests
                 </li>
                 <li className={this.state.linkedinUrl || this.state.githubUrl ? 'complete' : ''}>
-                  {this.state.linkedinUrl || this.state.githubUrl ? '✓' : '○'} Professional link
+                  {this.state.linkedinUrl || this.state.githubUrl ? '✓' : '○'}
+                  {' '}
+                  Professional link
                 </li>
                 <li className={this.state.portfolioUrl || this.state.personalWebsite ? 'complete' : ''}>
-                  {this.state.portfolioUrl || this.state.personalWebsite ? '✓' : '○'} Portfolio/website
+                  {this.state.portfolioUrl || this.state.personalWebsite ? '✓' : '○'}
+                  {' '}
+                  Portfolio/website
                 </li>
                 <li className={this.state.pronouns ? 'complete' : ''}>
-                  {this.state.pronouns ? '✓' : '○'} Pronouns
+                  {this.state.pronouns ? '✓' : '○'}
+                  {' '}
+                  Pronouns
                 </li>
               </ul>
             </div>

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -4,51 +4,425 @@ import { Link } from 'react-router-dom';
 import './careerProfile.scss';
 
 export default class CareerProfile extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      bio: props.profile.bio || '',
+      pronouns: props.profile.pronouns || '',
+      linkedinUrl: props.profile.linkedinUrl || '',
+      githubUrl: props.profile.githubUrl || '',
+      portfolioUrl: props.profile.portfolioUrl || '',
+      personalWebsite: props.profile.personalWebsite || '',
+      resumeUrl: props.profile.resumeUrl || '',
+      skills: props.profile.skills || [],
+      careerInterests: props.profile.careerInterests || [],
+      isProfilePublic: props.profile.isProfilePublic !== undefined ? props.profile.isProfilePublic : true,
+      skillInput: '',
+      careerInterestInput: '',
+      saving: false,
+      saveSuccess: false,
+      saveError: null,
+    };
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
+    this.handleToggle = this.handleToggle.bind(this);
+    this.addSkill = this.addSkill.bind(this);
+    this.removeSkill = this.removeSkill.bind(this);
+    this.addCareerInterest = this.addCareerInterest.bind(this);
+    this.removeCareerInterest = this.removeCareerInterest.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.profile !== this.props.profile) {
+      this.setState({
+        bio: this.props.profile.bio || '',
+        pronouns: this.props.profile.pronouns || '',
+        linkedinUrl: this.props.profile.linkedinUrl || '',
+        githubUrl: this.props.profile.githubUrl || '',
+        portfolioUrl: this.props.profile.portfolioUrl || '',
+        personalWebsite: this.props.profile.personalWebsite || '',
+        resumeUrl: this.props.profile.resumeUrl || '',
+        skills: this.props.profile.skills || [],
+        careerInterests: this.props.profile.careerInterests || [],
+        isProfilePublic: this.props.profile.isProfilePublic !== undefined ? this.props.profile.isProfilePublic : true,
+      });
+    }
+  }
+
+  handleInputChange(e) {
+    this.setState({ [e.target.name]: e.target.value });
+  }
+
+  handleToggle() {
+    this.setState(prevState => ({ isProfilePublic: !prevState.isProfilePublic }));
+  }
+
+  addSkill(e) {
+    if (e.key === 'Enter' && this.state.skillInput.trim()) {
+      e.preventDefault();
+      const newSkill = this.state.skillInput.trim();
+      if (this.state.skills.length < 20 && !this.state.skills.includes(newSkill)) {
+        this.setState(prevState => ({
+          skills: [...prevState.skills, newSkill],
+          skillInput: '',
+        }));
+      }
+    }
+  }
+
+  removeSkill(skillToRemove) {
+    this.setState(prevState => ({
+      skills: prevState.skills.filter(skill => skill !== skillToRemove),
+    }));
+  }
+
+  addCareerInterest(e) {
+    if (e.key === 'Enter' && this.state.careerInterestInput.trim()) {
+      e.preventDefault();
+      const newInterest = this.state.careerInterestInput.trim();
+      if (this.state.careerInterests.length < 20 && !this.state.careerInterests.includes(newInterest)) {
+        this.setState(prevState => ({
+          careerInterests: [...prevState.careerInterests, newInterest],
+          careerInterestInput: '',
+        }));
+      }
+    }
+  }
+
+  removeCareerInterest(interestToRemove) {
+    this.setState(prevState => ({
+      careerInterests: prevState.careerInterests.filter(interest => interest !== interestToRemove),
+    }));
+  }
+
+  async handleSubmit(e) {
+    e.preventDefault();
+    this.setState({ saving: true, saveError: null, saveSuccess: false });
+
+    const updates = {
+      bio: this.state.bio,
+      pronouns: this.state.pronouns,
+      skills: this.state.skills,
+      careerInterests: this.state.careerInterests,
+      isProfilePublic: this.state.isProfilePublic,
+    };
+
+    // Only include URL fields if they have values
+    if (this.state.linkedinUrl) updates.linkedinUrl = this.state.linkedinUrl;
+    if (this.state.githubUrl) updates.githubUrl = this.state.githubUrl;
+    if (this.state.portfolioUrl) updates.portfolioUrl = this.state.portfolioUrl;
+    if (this.state.personalWebsite) updates.personalWebsite = this.state.personalWebsite;
+    if (this.state.resumeUrl) updates.resumeUrl = this.state.resumeUrl;
+
+    try {
+      await this.props.updateCareerProfile(updates);
+      this.setState({ saving: false, saveSuccess: true });
+      setTimeout(() => this.setState({ saveSuccess: false }), 3000);
+    } catch (error) {
+      this.setState({ saving: false, saveError: error.message || 'Failed to save changes' });
+    }
+  }
+
+  calculateCompleteness() {
+    let completed = 0;
+    const total = 6;
+
+    if (this.state.bio && this.state.bio.length >= 50) completed++;
+    if (this.state.skills.length >= 3) completed++;
+    if (this.state.careerInterests.length >= 2) completed++;
+    if (this.state.linkedinUrl || this.state.githubUrl) completed++;
+    if (this.state.portfolioUrl || this.state.personalWebsite) completed++;
+    if (this.state.pronouns) completed++;
+
+    return Math.round((completed / total) * 100);
+  }
+
   render() {
+    const completeness = this.calculateCompleteness();
+
     return (
       <div className="career-profile-page">
         <div className="career-profile-header">
-          <Link to="/profile" className="back-link">
+          <Link to="/profile/career" className="back-link">
             <i className="fa fa-arrow-left" />
-            <span>Back to Profile</span>
+            <span>Back to Career Hub</span>
           </Link>
-          <h1>Career Profile</h1>
+          <h1>Edit Career Profile</h1>
           <p className="subtitle">Showcase your skills and experience to the ACM community</p>
         </div>
 
         <div className="career-profile-container">
           {/* Left Side: Form */}
           <div className="career-profile-content">
-            <div className="coming-soon-card">
-              <i className="fa fa-briefcase fa-3x" style={{ color: '#3B59ED', marginBottom: '20px' }} />
-              <h2>Career Profile Coming Soon!</h2>
-              <p>We're building a comprehensive career profile feature where you'll be able to:</p>
-              <ul>
-                <li>✨ Add your bio and pronouns</li>
-                <li>🔗 Link your LinkedIn, GitHub, and portfolio</li>
-                <li>💼 Showcase your skills and interests</li>
-                <li>👁️ Control your profile visibility</li>
-                <li>📊 Track your profile completeness</li>
-              </ul>
-              <p className="note">Check back soon or watch for updates!</p>
-            </div>
+            <form onSubmit={this.handleSubmit}>
+              {/* Basic Info Section */}
+              <div className="form-section">
+                <h2>Basic Information</h2>
+                
+                <div className="form-group">
+                  <label htmlFor="pronouns">Pronouns</label>
+                  <input
+                    type="text"
+                    id="pronouns"
+                    name="pronouns"
+                    value={this.state.pronouns}
+                    onChange={this.handleInputChange}
+                    placeholder="e.g., she/her, he/him, they/them"
+                    maxLength={50}
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="bio">
+                    Bio
+                    <span className="char-count">{this.state.bio.length}/1000</span>
+                  </label>
+                  <textarea
+                    id="bio"
+                    name="bio"
+                    value={this.state.bio}
+                    onChange={this.handleInputChange}
+                    placeholder="Tell us about yourself, your interests, and what you're working on..."
+                    rows={6}
+                    maxLength={1000}
+                  />
+                </div>
+              </div>
+
+              {/* Professional Links Section */}
+              <div className="form-section">
+                <h2>Professional Links</h2>
+                
+                <div className="form-group">
+                  <label htmlFor="linkedinUrl">
+                    <i className="fab fa-linkedin" />
+                    {' '}
+                    LinkedIn
+                  </label>
+                  <input
+                    type="url"
+                    id="linkedinUrl"
+                    name="linkedinUrl"
+                    value={this.state.linkedinUrl}
+                    onChange={this.handleInputChange}
+                    placeholder="https://linkedin.com/in/yourprofile"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="githubUrl">
+                    <i className="fab fa-github" />
+                    {' '}
+                    GitHub
+                  </label>
+                  <input
+                    type="url"
+                    id="githubUrl"
+                    name="githubUrl"
+                    value={this.state.githubUrl}
+                    onChange={this.handleInputChange}
+                    placeholder="https://github.com/yourusername"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="portfolioUrl">
+                    <i className="fa fa-briefcase" />
+                    {' '}
+                    Portfolio
+                    <span className="optional-label"> (Optional)</span>
+                  </label>
+                  <input
+                    type="url"
+                    id="portfolioUrl"
+                    name="portfolioUrl"
+                    value={this.state.portfolioUrl}
+                    onChange={this.handleInputChange}
+                    placeholder="https://yourportfolio.com"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="personalWebsite">
+                    <i className="fa fa-globe" />
+                    {' '}
+                    Personal Website
+                    <span className="optional-label"> (Optional)</span>
+                  </label>
+                  <input
+                    type="url"
+                    id="personalWebsite"
+                    name="personalWebsite"
+                    value={this.state.personalWebsite}
+                    onChange={this.handleInputChange}
+                    placeholder="https://yourwebsite.com"
+                  />
+                </div>
+
+                <div className="form-group">
+                  <label htmlFor="resumeUrl">
+                    <i className="fa fa-file-alt" />
+                    {' '}
+                    Resume URL
+                    <span className="optional-label"> (Optional)</span>
+                  </label>
+                  <input
+                    type="url"
+                    id="resumeUrl"
+                    name="resumeUrl"
+                    value={this.state.resumeUrl}
+                    onChange={this.handleInputChange}
+                    placeholder="https://drive.google.com/..."
+                  />
+                </div>
+              </div>
+
+              {/* Skills Section */}
+              <div className="form-section">
+                <h2>
+                  Skills
+                  <span className="count-badge">{this.state.skills.length}/20</span>
+                </h2>
+                <p className="section-help">Add your technical and soft skills. Press Enter to add each skill.</p>
+                
+                <div className="form-group">
+                  <input
+                    type="text"
+                    name="skillInput"
+                    value={this.state.skillInput}
+                    onChange={this.handleInputChange}
+                    onKeyDown={this.addSkill}
+                    placeholder="Type a skill and press Enter"
+                    maxLength={50}
+                    disabled={this.state.skills.length >= 20}
+                  />
+                </div>
+
+                <div className="tags-container">
+                  {this.state.skills.map(skill => (
+                    <span key={skill} className="tag">
+                      {skill}
+                      <button type="button" onClick={() => this.removeSkill(skill)}>×</button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Career Interests Section */}
+              <div className="form-section">
+                <h2>
+                  Career Interests
+                  <span className="count-badge">{this.state.careerInterests.length}/20</span>
+                </h2>
+                <p className="section-help">What career fields or roles interest you? Press Enter to add each interest.</p>
+                
+                <div className="form-group">
+                  <input
+                    type="text"
+                    name="careerInterestInput"
+                    value={this.state.careerInterestInput}
+                    onChange={this.handleInputChange}
+                    onKeyDown={this.addCareerInterest}
+                    placeholder="Type a career interest and press Enter"
+                    maxLength={50}
+                    disabled={this.state.careerInterests.length >= 20}
+                  />
+                </div>
+
+                <div className="tags-container">
+                  {this.state.careerInterests.map(interest => (
+                    <span key={interest} className="tag">
+                      {interest}
+                      <button type="button" onClick={() => this.removeCareerInterest(interest)}>×</button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {/* Privacy Section */}
+              <div className="form-section">
+                <h2>Privacy Settings</h2>
+                
+                <div className="toggle-group">
+                  <label className="toggle-label">
+                    <input
+                      type="checkbox"
+                      checked={this.state.isProfilePublic}
+                      onChange={this.handleToggle}
+                    />
+                    <span className="toggle-switch" />
+                    <span className="toggle-text">
+                      Make my career profile public
+                      <span className="toggle-description">
+                        Allow other ACM members and recruiters to view your career profile in the directory
+                      </span>
+                    </span>
+                  </label>
+                </div>
+              </div>
+
+              {/* Save Button */}
+              <div className="form-actions">
+                {this.state.saveError && (
+                  <div className="error-message">
+                    <i className="fa fa-exclamation-circle" />
+                    {' '}
+                    {this.state.saveError}
+                  </div>
+                )}
+                {this.state.saveSuccess && (
+                  <div className="success-message">
+                    <i className="fa fa-check-circle" />
+                    {' '}
+                    Profile saved successfully!
+                  </div>
+                )}
+                <button type="submit" className="save-button" disabled={this.state.saving}>
+                  {this.state.saving ? 'Saving...' : 'Save Changes'}
+                </button>
+              </div>
+            </form>
           </div>
 
-          {/* Right Side: Preview/Stats */}
+          {/* Right Side: Stats & Tips */}
           <div className="career-profile-sidebar">
+            <div className="info-card">
+              <h3>Profile Completeness</h3>
+              <div className="progress-bar">
+                <div className="progress-fill" style={{ width: `${completeness}%` }} />
+              </div>
+              <p className="progress-text">{completeness}% Complete</p>
+              <ul className="completeness-checklist">
+                <li className={this.state.bio && this.state.bio.length >= 50 ? 'complete' : ''}>
+                  {this.state.bio && this.state.bio.length >= 50 ? '✓' : '○'} Bio (50+ characters)
+                </li>
+                <li className={this.state.skills.length >= 3 ? 'complete' : ''}>
+                  {this.state.skills.length >= 3 ? '✓' : '○'} At least 3 skills
+                </li>
+                <li className={this.state.careerInterests.length >= 2 ? 'complete' : ''}>
+                  {this.state.careerInterests.length >= 2 ? '✓' : '○'} At least 2 career interests
+                </li>
+                <li className={this.state.linkedinUrl || this.state.githubUrl ? 'complete' : ''}>
+                  {this.state.linkedinUrl || this.state.githubUrl ? '✓' : '○'} Professional link
+                </li>
+                <li className={this.state.portfolioUrl || this.state.personalWebsite ? 'complete' : ''}>
+                  {this.state.portfolioUrl || this.state.personalWebsite ? '✓' : '○'} Portfolio/website
+                </li>
+                <li className={this.state.pronouns ? 'complete' : ''}>
+                  {this.state.pronouns ? '✓' : '○'} Pronouns
+                </li>
+              </ul>
+            </div>
+
             <div className="info-card">
               <h3>📈 Profile Tips</h3>
               <ul>
-                <li>Complete your bio (150+ chars recommended)</li>
-                <li>Add at least 5 skills</li>
-                <li>Link your professional profiles</li>
-                <li>Make your profile public to increase visibility</li>
+                <li>Write a compelling bio that highlights your interests</li>
+                <li>Add specific, relevant skills</li>
+                <li>Include links to your best work</li>
+                <li>Make your profile public to increase networking opportunities</li>
               </ul>
-            </div>
-
-            <div className="info-card">
-              <h3>🎯 Why Build Your Career Profile?</h3>
-              <p>Connect with recruiters, showcase your projects, and network with other ACM members!</p>
             </div>
           </div>
         </div>
@@ -59,6 +433,7 @@ export default class CareerProfile extends React.Component {
 
 CareerProfile.propTypes = {
   profile: PropTypes.object,
+  updateCareerProfile: PropTypes.func.isRequired,
 };
 
 CareerProfile.defaultProps = {

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -106,15 +106,14 @@ export default class CareerProfile extends React.Component {
       skills: this.state.skills,
       careerInterests: this.state.careerInterests,
       isProfilePublic: this.state.isProfilePublic,
-      // Always include URL fields to allow clearing them
+      // Required fields
+      linkedinUrl: this.state.linkedinUrl,
+      githubUrl: this.state.githubUrl,
+      // Optional URL fields that can be cleared
       portfolioUrl: this.state.portfolioUrl,
       personalWebsite: this.state.personalWebsite,
       resumeUrl: this.state.resumeUrl,
     };
-
-    // Only include LinkedIn/GitHub if they have values (validator enforces format)
-    if (this.state.linkedinUrl) updates.linkedinUrl = this.state.linkedinUrl;
-    if (this.state.githubUrl) updates.githubUrl = this.state.githubUrl;
 
     try {
       await this.props.updateCareerProfile(updates);
@@ -211,6 +210,7 @@ export default class CareerProfile extends React.Component {
                     value={this.state.linkedinUrl}
                     onChange={this.handleInputChange}
                     placeholder="https://linkedin.com/in/yourprofile"
+                    required
                   />
                 </div>
 
@@ -227,6 +227,7 @@ export default class CareerProfile extends React.Component {
                     value={this.state.githubUrl}
                     onChange={this.handleInputChange}
                     placeholder="https://github.com/yourusername"
+                    required
                   />
                 </div>
 

--- a/src/components/Profile/ProfileCard.jsx
+++ b/src/components/Profile/ProfileCard.jsx
@@ -148,7 +148,7 @@ export default class ProfileCard extends React.Component {
         <div className="profile-card-divider" />
 
         <div className="profile-card-actions">
-          <Link to="/profile/career" className="card-link">
+          <Link to="/profile/career/edit" className="card-link">
             <i className="fa fa-briefcase" />
             <span>Career Profile</span>
           </Link>

--- a/src/components/Profile/careerLanding.scss
+++ b/src/components/Profile/careerLanding.scss
@@ -1,0 +1,362 @@
+@use 'styles/vars.scss';
+
+.career-landing {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 40px 20px;
+
+  .career-landing-header {
+    text-align: center;
+    margin-bottom: 40px;
+
+    h1 {
+      font-size: 2.5rem;
+      color: #333;
+      margin-bottom: 10px;
+    }
+
+    p {
+      font-size: 1.1rem;
+      color: #666;
+    }
+  }
+
+  .career-landing-content {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 30px;
+    align-items: start;
+  }
+
+  .career-cards-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .profile-preview {
+    background: white;
+    border-radius: 12px;
+    padding: 30px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    position: sticky;
+    top: 20px;
+
+    .preview-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 25px;
+      padding-bottom: 15px;
+      border-bottom: 2px solid #e9ecef;
+
+      h2 {
+        font-size: 1.5rem;
+        color: #333;
+        margin: 0;
+      }
+
+      .edit-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 20px;
+        background: rgb(47, 126, 230);
+        color: white;
+        text-decoration: none;
+        border-radius: 8px;
+        font-weight: 500;
+        transition: all 0.3s ease;
+
+        &:hover {
+          background: #2666cc;
+          transform: translateY(-2px);
+        }
+
+        i {
+          font-size: 14px;
+        }
+      }
+    }
+
+    .preview-content {
+      .preview-section {
+        margin-bottom: 25px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+
+        h3 {
+          font-size: 1rem;
+          color: #666;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          margin-bottom: 12px;
+          font-weight: 600;
+        }
+
+        p {
+          color: #333;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+
+          .tag {
+            display: inline-block;
+            padding: 6px 14px;
+            background: #e9ecef;
+            color: #333;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            font-weight: 500;
+          }
+        }
+
+        .preview-links {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+
+          .preview-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 16px;
+            background: #f8f9fa;
+            color: rgb(47, 126, 230);
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: 500;
+            transition: all 0.3s ease;
+
+            &:hover {
+              background: rgb(47, 126, 230);
+              color: white;
+              transform: translateY(-2px);
+            }
+
+            i {
+              font-size: 16px;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .career-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+  }
+
+  .career-card {
+    background: white;
+    border-radius: 12px;
+    padding: 25px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.3s ease;
+    position: relative;
+    cursor: pointer;
+
+    &:not(.disabled):hover {
+      transform: translateY(-4px);
+      box-shadow: 0 4px 16px rgba(47, 126, 230, 0.2);
+    }
+
+    &.disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      background: #f8f9fa;
+    }
+
+    .career-card-icon {
+      flex-shrink: 0;
+      width: 50px;
+      height: 50px;
+      border-radius: 10px;
+      background: linear-gradient(135deg, rgb(47, 126, 230) 0%, #5a9aef 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      i {
+        font-size: 24px;
+        color: white;
+      }
+    }
+
+    .career-card-content {
+      flex: 1;
+
+      h2 {
+        font-size: 1.3rem;
+        margin-bottom: 8px;
+        color: #333;
+      }
+
+      p {
+        font-size: 0.95rem;
+        color: #666;
+        line-height: 1.5;
+        margin-bottom: 12px;
+      }
+
+      .profile-status {
+        margin-top: 15px;
+
+        .status-bar {
+          width: 100%;
+          height: 6px;
+          background: #e9ecef;
+          border-radius: 3px;
+          overflow: hidden;
+          margin-bottom: 6px;
+
+          .status-fill {
+            height: 100%;
+            background: linear-gradient(90deg, rgb(47, 126, 230) 0%, #5a9aef 100%);
+            border-radius: 3px;
+            transition: width 0.3s ease;
+          }
+        }
+
+        .status-text {
+          font-size: 0.85rem;
+          color: #666;
+          font-weight: 500;
+        }
+      }
+
+      .privacy-badge {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 4px 10px;
+        background: #ffc107;
+        color: #333;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: 500;
+
+        i {
+          margin-right: 4px;
+        }
+      }
+
+      .coming-soon-badge {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 4px 10px;
+        background: #e9ecef;
+        color: #666;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+    }
+
+    .career-card-arrow {
+      position: absolute;
+      right: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: rgb(47, 126, 230);
+      font-size: 20px;
+    }
+
+    &.disabled .career-card-arrow {
+      display: none;
+    }
+  }
+
+  .career-tips {
+    background: #f8f9fa;
+    border-radius: 12px;
+    padding: 30px;
+    border-left: 4px solid rgb(47, 126, 230);
+
+    h3 {
+      font-size: 1.3rem;
+      color: #333;
+      margin-bottom: 15px;
+
+      i {
+        color: rgb(47, 126, 230);
+        margin-right: 8px;
+      }
+    }
+
+    p {
+      color: #666;
+      margin-bottom: 15px;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      li {
+        padding: 8px 0;
+        padding-left: 25px;
+        position: relative;
+        color: #555;
+
+        &:before {
+          content: "→";
+          position: absolute;
+          left: 0;
+          color: rgb(47, 126, 230);
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}
+
+@media (max-width: 1024px) {
+  .career-landing {
+    .career-landing-content {
+      grid-template-columns: 1fr;
+    }
+
+    .profile-preview {
+      position: relative;
+      top: 0;
+      order: -1;
+    }
+
+    .career-cards {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .career-landing {
+    padding: 80px 15px 20px 15px;
+
+    .career-landing-header {
+      margin-top: 0;
+
+      h1 {
+        font-size: 2rem;
+      }
+    }
+
+    .career-cards {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/components/Profile/careerProfile.scss
+++ b/src/components/Profile/careerProfile.scss
@@ -359,6 +359,14 @@
     }
 
     .career-profile-sidebar {
+      position: sticky;
+      top: 100px;
+      align-self: flex-start;
+
+      @media (max-width: 900px) {
+        position: static;
+      }
+
       .info-card {
         background: white;
         border-radius: 12px;

--- a/src/components/Profile/careerProfile.scss
+++ b/src/components/Profile/careerProfile.scss
@@ -57,6 +57,264 @@
     .career-profile-content {
       min-width: 0;
 
+      form {
+        background: white;
+        border-radius: 12px;
+        padding: 40px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+
+        .form-section {
+          margin-bottom: 32px;
+          padding-bottom: 32px;
+          border-bottom: 1px solid #e5e7eb;
+
+          &:last-child {
+            border-bottom: none;
+            margin-bottom: 0;
+            padding-bottom: 0;
+          }
+
+          h2 {
+            font-size: 1.5em;
+            color: #333;
+            margin: 0 0 8px 0;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+
+            .count-badge {
+              font-size: 0.6em;
+              background: vars.$secondary-color;
+              color: white;
+              padding: 4px 12px;
+              border-radius: 12px;
+              font-weight: 500;
+            }
+          }
+
+          .section-help {
+            color: #666;
+            font-size: 0.9em;
+            margin: 0 0 20px 0;
+          }
+
+          .form-group {
+            margin-bottom: 20px;
+
+            label {
+              display: block;
+              font-weight: 600;
+              color: #374151;
+              margin-bottom: 8px;
+              font-size: 0.95em;
+
+              i {
+                margin-right: 6px;
+                color: vars.$secondary-color;
+              }
+
+              .char-count {
+                float: right;
+                font-weight: normal;
+                color: #9ca3af;
+                font-size: 0.9em;
+              }
+
+              .optional-label {
+                font-weight: normal;
+                color: #9ca3af;
+                font-size: 0.85em;
+              }
+            }
+
+            input[type="text"],
+            input[type="url"],
+            textarea {
+              width: 100%;
+              padding: 12px 16px;
+              border: 1px solid #d1d5db;
+              border-radius: 8px;
+              font-size: 0.95em;
+              font-family: inherit;
+              transition: all 0.2s ease;
+              box-sizing: border-box;
+
+              &:focus {
+                outline: none;
+                border-color: vars.$secondary-color;
+                box-shadow: 0 0 0 3px rgba(47, 126, 230, 0.1);
+              }
+
+              &:disabled {
+                background: #f3f4f6;
+                cursor: not-allowed;
+              }
+
+              &::placeholder {
+                color: #9ca3af;
+              }
+            }
+
+            textarea {
+              resize: vertical;
+              min-height: 120px;
+              line-height: 1.6;
+            }
+          }
+
+          .tags-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            min-height: 40px;
+            padding: 8px 0;
+
+            .tag {
+              display: inline-flex;
+              align-items: center;
+              gap: 6px;
+              background: #e0e7ff;
+              color: #4338ca;
+              padding: 6px 12px;
+              border-radius: 20px;
+              font-size: 0.9em;
+              font-weight: 500;
+
+              button {
+                background: none;
+                border: none;
+                color: #4338ca;
+                font-size: 1.3em;
+                line-height: 1;
+                cursor: pointer;
+                padding: 0;
+                margin: 0;
+                transition: opacity 0.2s ease;
+
+                &:hover {
+                  opacity: 0.7;
+                }
+              }
+            }
+          }
+
+          .toggle-group {
+            .toggle-label {
+              display: flex;
+              align-items: flex-start;
+              gap: 12px;
+              cursor: pointer;
+              user-select: none;
+
+              input[type="checkbox"] {
+                display: none;
+              }
+
+              .toggle-switch {
+                position: relative;
+                width: 48px;
+                height: 24px;
+                background: #d1d5db;
+                border-radius: 12px;
+                transition: background 0.2s ease;
+                flex-shrink: 0;
+
+                &:after {
+                  content: "";
+                  position: absolute;
+                  top: 2px;
+                  left: 2px;
+                  width: 20px;
+                  height: 20px;
+                  background: white;
+                  border-radius: 50%;
+                  transition: transform 0.2s ease;
+                }
+              }
+
+              input[type="checkbox"]:checked + .toggle-switch {
+                background: vars.$secondary-color;
+
+                &:after {
+                  transform: translateX(24px);
+                }
+              }
+
+              .toggle-text {
+                flex: 1;
+                font-weight: 600;
+                color: #374151;
+
+                .toggle-description {
+                  display: block;
+                  font-weight: normal;
+                  color: #6b7280;
+                  font-size: 0.9em;
+                  margin-top: 4px;
+                }
+              }
+            }
+          }
+        }
+
+        .form-actions {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          margin-top: 32px;
+
+          .error-message,
+          .success-message {
+            padding: 12px 16px;
+            border-radius: 8px;
+            font-size: 0.95em;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+
+            i {
+              font-size: 1.1em;
+            }
+          }
+
+          .error-message {
+            background: #fee2e2;
+            color: #991b1b;
+            border: 1px solid #fca5a5;
+          }
+
+          .success-message {
+            background: #d1fae5;
+            color: #065f46;
+            border: 1px solid #6ee7b7;
+          }
+
+          .save-button {
+            padding: 14px 28px;
+            background: vars.$secondary-color;
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 1em;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            align-self: flex-start;
+
+            &:hover:not(:disabled) {
+              background: #2666cc;
+              transform: translateY(-1px);
+              box-shadow: 0 4px 12px rgba(47, 126, 230, 0.3);
+            }
+
+            &:disabled {
+              opacity: 0.6;
+              cursor: not-allowed;
+            }
+          }
+        }
+      }
+
       .coming-soon-card {
         background: white;
         border-radius: 12px;
@@ -119,6 +377,52 @@
           color: #666;
           line-height: 1.6;
           margin: 0;
+        }
+
+        .progress-bar {
+          width: 100%;
+          height: 8px;
+          background: #e5e7eb;
+          border-radius: 4px;
+          overflow: hidden;
+          margin: 12px 0;
+
+          .progress-fill {
+            height: 100%;
+            background: linear-gradient(90deg, vars.$secondary-color, #5a9aef);
+            border-radius: 4px;
+            transition: width 0.3s ease;
+          }
+        }
+
+        .progress-text {
+          font-weight: 600;
+          color: vars.$secondary-color;
+          font-size: 1.1em;
+          margin: 8px 0 16px 0;
+        }
+
+        .completeness-checklist {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+
+          li {
+            padding: 8px 0;
+            font-size: 0.9em;
+            color: #6b7280;
+            border-bottom: 1px solid #f0f0f0;
+            transition: color 0.2s ease;
+
+            &.complete {
+              color: #059669;
+              font-weight: 500;
+            }
+
+            &:last-child {
+              border-bottom: none;
+            }
+          }
         }
 
         ul {

--- a/src/components/Topbar/ProfileDropdown.jsx
+++ b/src/components/Topbar/ProfileDropdown.jsx
@@ -55,7 +55,7 @@ export default class ProfileDropdown extends React.Component {
               <i className="fa fa-user" />
               <span>My Profile</span>
             </Link>
-            <Link to="/profile/career" className="dropdown-item" onClick={this.toggleDropdown}>
+            <Link to="/profile/career/edit" className="dropdown-item" onClick={this.toggleDropdown}>
               <i className="fa fa-briefcase" />
               <span>Career Profile</span>
             </Link>

--- a/src/components/Topbar/index.jsx
+++ b/src/components/Topbar/index.jsx
@@ -46,6 +46,9 @@ export default class Topbar extends React.Component {
         <NavLink to="/leaderboard" activeClassName="selected">
           <NavigationItem icon="fa-list" text={isAdmin ? 'Members' : 'Leaderboard'} />
         </NavLink>
+        <NavLink to="/profile/career" activeClassName="selected">
+          <NavigationItem icon="fa-briefcase" text="Career Hub" />
+        </NavLink>
         <NavLink to="/resources" activeClassName="selected">
           <NavigationItem icon={isAdmin ? 'fa-building' : 'fa-file'} text={isAdmin ? 'Organization' : 'Resources'} />
         </NavLink>
@@ -69,12 +72,24 @@ export default class Topbar extends React.Component {
               </NavLink>
             )}
 
-            {/* Add Profile Link (Mobile only) */}
-            {!isAdmin && (
-              <NavLink to="/profile" className="topbar-profile-mobile navigation-item" activeClassName="selected">
-                <NavigationItem icon="fa-user-circle" text="Profile" />
-              </NavLink>
+            {/* Mobile only items */}
+            <NavLink to="/profile" className="topbar-mobile-only" activeClassName="selected">
+              <NavigationItem icon="fa-user-circle" text="Profile" />
+            </NavLink>
+            
+            {this.props.isRealAdmin && (
+              <a className="topbar-mobile-only" onClick={this.props.onToggleAdminView}>
+                <div className="navigation-item">
+                  <span>{this.props.adminView ? 'Member View' : 'Admin View'}</span>
+                </div>
+              </a>
             )}
+            
+            <a className="topbar-mobile-only signout-link" onClick={this.props.onLogout}>
+              <div className="navigation-item">
+                <span>Sign Out</span>
+              </div>
+            </a>
           </div>
 
           {/* Hamburger Button (Mobile only) */}
@@ -85,6 +100,7 @@ export default class Topbar extends React.Component {
           {/* Profile Icon (Desktop only) */}
           {!isAdmin && (
             <ProfileDropdown 
+              className="topbar-desktop-only"
               picture={this.props.picture} 
               onLogout={this.props.onLogout}
               isAdmin={this.props.isRealAdmin}

--- a/src/components/Topbar/index.jsx
+++ b/src/components/Topbar/index.jsx
@@ -73,7 +73,7 @@ export default class Topbar extends React.Component {
             )}
 
             {/* Mobile only items */}
-            <NavLink to="/profile" className="topbar-mobile-only" activeClassName="selected">
+            <NavLink to="/profile" exact className="topbar-mobile-only" activeClassName="selected">
               <NavigationItem icon="fa-user-circle" text="Profile" />
             </NavLink>
             

--- a/src/components/Topbar/style.scss
+++ b/src/components/Topbar/style.scss
@@ -18,7 +18,7 @@
     align-items: center;
     width: 100%;
     height: 100%;
-    position: relative; 
+    position: relative;
   }
 
   .topbar-logo {
@@ -41,7 +41,7 @@
     padding: 0px 10px;
     font-size: 1.3em;
     font-weight: 400;
-    color: #A4A4A4;
+    color: #a4a4a4;
     transition: 0.125s ease-in-out;
 
     &:hover {
@@ -73,63 +73,57 @@
       border-color: vars.$secondaryblue;
     }
   }
-  
 
   .topbar-links {
-  display: flex; 
-  flex-grow: 1;
-  align-items: center;
+    display: flex;
+    flex-grow: 1;
+    align-items: center;
 
-  &.open {
-    flex-direction: column;
-    position: absolute;
-    top: 61px;
-    left: 0;
-    width: 100%;
-    background-color: white;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    z-index: 8;
-    animation: slideDown 0.3s ease-out forwards;
+    &.open {
+      flex-direction: column;
+      position: absolute;
+      top: 61px;
+      left: 0;
+      width: 100%;
+      background-color: white;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+      z-index: 8;
+      animation: slideDown 0.3s ease-out forwards;
+    }
   }
-}
 
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-20px);
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
   .hamburger {
-  display: none;
-  font-size: 24px;
-  cursor: pointer;
-  padding: 8px;
-  margin-left: auto;
-  margin-right: 40px;
-  transition: transform 0.3s ease;
-  
-  i {
-    transition: all 0.3s ease;
-  }
-  
-  &.open i {
-    transform: rotate(90deg);
-  }
-}
-
-  .topbar-profile-mobile {
     display: none;
-    color: #A4A4A4;
+    font-size: 24px;
+    cursor: pointer;
+    padding: 8px;
+    margin-left: auto;
+    margin-right: 40px;
+    transition: transform 0.3s ease;
 
-    &:hover {
-      color: vars.$secondaryblue;
+    i {
+      transition: all 0.3s ease;
     }
-  } 
+
+    &.open i {
+      transform: rotate(90deg);
+    }
+  }
+
+  .topbar-mobile-only {
+    display: none;
+  }
 
   // Responsive styling
   @media (max-width: 768px) {
@@ -149,22 +143,35 @@
       display: block;
     }
 
-    .topbar-profile {
-      display: none;
+    .profile-dropdown {
+      display: none !important;
     }
 
-    .topbar-profile-mobile {
+    .topbar-mobile-only {
       display: flex;
-      align-items: center;
-      color: #A4A4A4;
-      font-size: 1em;
-      font-weight: 400;
-      text-align: center;
+      text-decoration: none;
+      cursor: pointer;
+      width: 100%;
+      justify-content: center;
 
-      &:hover {
-        color: vars.$secondaryblue;
-        cursor: pointer;
+      .navigation-item {
+        width: 100%;
+        text-align: center;
+      }
+
+      &.signout-link {
+        border-top: 1px solid #e0e0e0;
+        margin-top: 10px;
+        padding-top: 10px;
+
+        .navigation-item {
+          color: #dc3545 !important;
+
+          &:hover {
+            color: #bb2d3b !important;
+          }
+        }
       }
     }
   }
-} 
+}

--- a/src/config.js
+++ b/src/config.js
@@ -10,6 +10,7 @@ export default {
   routes: {
     user: {
       user: '/api/v1/user',
+      career: '/api/v1/user/career',
       activity: '/api/v1/user/activity',
       admins: '/api/v1/user/admins',
     },

--- a/src/containers/careerLanding.js
+++ b/src/containers/careerLanding.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Action } from 'reducers';
 import Topbar from 'containers/topbar';
-import CareerProfile from 'components/Profile/CareerProfile';
+import CareerLanding from 'components/Profile/CareerLanding';
 
-class CareerProfileContainer extends React.Component {
+class CareerLandingContainer extends React.Component {
   componentWillMount() {
     if (this.props.authenticated) {
       this.props.fetchUser();
@@ -15,10 +15,7 @@ class CareerProfileContainer extends React.Component {
     return (
       <div>
         <Topbar />
-        <CareerProfile 
-          profile={this.props.profile} 
-          updateCareerProfile={this.props.updateCareerProfile}
-        />
+        <CareerLanding profile={this.props.profile} />
       </div>
     );
   }
@@ -39,7 +36,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   fetchUser: () => dispatch(Action.FetchUser()),
-  updateCareerProfile: (user) => dispatch(Action.UpdateCareerProfile(user)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(CareerProfileContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(CareerLandingContainer);

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import Events from 'containers/events';
 import Login from 'containers/login';
 import Register from 'containers/register';
 import Profile from 'containers/profile';
+import CareerLanding from 'containers/careerLanding';
 import CareerProfile from 'containers/careerProfile';
 import Leaderboard from 'containers/leaderboard';
 import ControlPanel from 'containers/controlPanel';
@@ -32,7 +33,8 @@ class App extends React.Component {
               <Route path="/register" component={requireAuth(Register)} />
               <Route path="/home" component={requireAuth(Home)} />
               <Route path="/events" component={requireAuth(Events)} />
-              <Route path="/profile/career" component={requireAuth(CareerProfile)} />
+              <Route path="/profile/career/edit" component={requireAuth(CareerProfile)} />
+              <Route path="/profile/career" component={requireAuth(CareerLanding)} />
               <Route path="/profile" component={requireAuth(Profile)} />
               <Route path="/resources" component={requireAuth(Resources)} />
               <Route path="/leaderboard" component={requireAuth(Leaderboard)} />

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,7 +6,7 @@ import { routerReducer, routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
 
 import {
-  User, FetchUser, UpdateUser, UserUpdateDone, FetchActivity,
+  User, FetchUser, UpdateUser, UpdateCareerProfile, UserUpdateDone, FetchActivity,
 } from './user';
 import {
   Admins, FetchAdmins, AddAdmin, DeleteAdmin, ChangeSuperAdmin,
@@ -63,6 +63,7 @@ const Action = {
   ChangeOneClickPasswordDone,
   FetchUser,
   UpdateUser,
+  UpdateCareerProfile,
   UserUpdateDone,
   FetchActivity,
   AddAdmin,

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -64,6 +64,7 @@ class State {
 
 const FetchUser = () => async (dispatch) => {
   try {
+    // Fetch basic profile
     const response = await fetch(Config.API_URL + Config.routes.user.user, {
       method: 'GET',
       headers: {
@@ -82,7 +83,23 @@ const FetchUser = () => async (dispatch) => {
     if (!data) throw new Error('Empty response from server');
     if (data.error) throw new Error(data.error.message);
 
-    dispatch(State.FetchUser(null, data.user));
+    // Fetch career profile
+    const careerResponse = await fetch(Config.API_URL + Config.routes.user.career, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Storage.get('token')}`,
+      },
+    });
+
+    const careerData = await careerResponse.json();
+    if (careerData && !careerData.error && careerData.user) {
+      // Merge career data with user profile
+      dispatch(State.FetchUser(null, { ...data.user, ...careerData.user }));
+    } else {
+      dispatch(State.FetchUser(null, data.user));
+    }
   } catch (err) {
     dispatch(State.FetchUser(err.message));
   }

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -165,8 +165,13 @@ const UpdateCareerProfile = user => async (dispatch) => {
     if (!data) throw new Error('Empty response from server');
     if (data.error) throw new Error(data.error.message);
 
-    dispatch(State.FetchUser(null, data.user));
+    // Merge career profile data with existing profile instead of replacing
     dispatch(State.UpdateUser());
+    dispatch((innerDispatch, getState) => {
+      const currentProfile = getState().User.get('profile');
+      const mergedProfile = { ...currentProfile, ...data.user };
+      innerDispatch(State.FetchUser(null, mergedProfile));
+    });
   } catch (err) {
     dispatch(State.UpdateUser(err.message));
     throw err;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -105,6 +105,11 @@ const UpdateUser = user => async (dispatch) => {
       return dispatch(LogoutUser());
     }
 
+    if (status >= 400) {
+      const data = await response.json();
+      throw new Error(data.error?.message || `Server error: ${status}`);
+    }
+
     const data = await response.json();
     if (!data) throw new Error('Empty response from server');
     if (data.error) throw new Error(data.error.message);
@@ -113,6 +118,41 @@ const UpdateUser = user => async (dispatch) => {
     dispatch(State.UpdateUser());
   } catch (err) {
     dispatch(State.UpdateUser(err.message));
+    throw err;
+  }
+};
+
+const UpdateCareerProfile = user => async (dispatch) => {
+  try {
+    const response = await fetch(Config.API_URL + Config.routes.user.career, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Storage.get('token')}`,
+      },
+      body: JSON.stringify({ user }),
+    });
+
+    const status = await response.status;
+    if (status === 401 || status === 403) {
+      return dispatch(LogoutUser());
+    }
+
+    if (status >= 400) {
+      const data = await response.json();
+      throw new Error(data.error?.message || `Server error: ${status}`);
+    }
+
+    const data = await response.json();
+    if (!data) throw new Error('Empty response from server');
+    if (data.error) throw new Error(data.error.message);
+
+    dispatch(State.FetchUser(null, data.user));
+    dispatch(State.UpdateUser());
+  } catch (err) {
+    dispatch(State.UpdateUser(err.message));
+    throw err;
   }
 };
 
@@ -202,5 +242,5 @@ const User = (state = defaultState, action) => {
 const UserUpdateDone = () => ({ type: UPDATE_COMPLETED });
 
 export {
-  User, FetchUser, UpdateUser, UserUpdateDone, FetchActivity,
+  User, FetchUser, UpdateUser, UpdateCareerProfile, UserUpdateDone, FetchActivity,
 };


### PR DESCRIPTION
## Description

This PR implements a comprehensive Career Hub feature for the membership portal and fixes multiple mobile responsiveness issues across the application.

### Career Profile System
- **Career Profile Edit Page** (`/profile/career/edit`): Full-featured form for members to manage their professional profile including:
  - Bio (1000 char limit) with character counter
  - Pronouns field
  - Professional links (LinkedIn, GitHub, Portfolio, Personal Website, Resume URL)
  - Skills (tag-based input, max 20)
  - Career Interests (tag-based input, max 20)
  - Privacy toggle to make profile public/private for recruiters
  - Profile completeness tracker with real-time feedback
  - Save/error handling with user feedback

- **Career Hub Landing Page** (`/profile/career`): Central hub with 2/3-1/3 split layout featuring:
  - Live profile preview (sticky on desktop) showing all career information
  - Four action cards (2x2 grid on desktop, stacked on mobile):
    - My Career Profile (with completion percentage)
    - Recruitment (coming soon)
    - Committee Applications (coming soon)
    - Career Resources (coming soon)
  - Completion tips section for incomplete profiles

- **Redux Integration**: Added `UpdateCareerProfile` action that sends data to `/api/v1/user/career` endpoint with proper error handling and state updates

### Navigation & Layout
- Added **Career Hub** tab to topbar navigation (between Leaderboard and Resources)
- Updated profile card to link directly to career edit page
- Proper navigation flow: Profile → Career Hub → Edit Career Profile → Back to Profile

### Bug Fixes
- **SCSS compilation**: Fixed deprecated `@import` (changed to `@use`) in career landing page styles
- **Font Awesome icons**: Changed brand icons from `fa` to `fab` class for LinkedIn/GitHub
- **Form validation**: Empty URL fields now excluded from request payload to prevent backend validation errors
- **Input styling**: Added `box-sizing: border-box` to prevent right-skewed inputs

### Mobile Responsiveness Overhaul
- **Career Hub**: 
  - Single column layout on mobile with proper stacking
  - 80px top padding to prevent topbar overlap
  - Cards display vertically (4x1) instead of 2x2 grid on mobile

- **Topbar Mobile Menu**:
  - Hidden profile dropdown on mobile (was duplicating with hamburger menu)
  - Added Profile, Admin View toggle, and Sign Out directly to hamburger menu
  - Consistent styling using `.navigation-item` class structure
  - Red-colored Sign Out with divider separator

- **Admin Events View**:
  - Event tiles stack vertically on mobile
  - Cover images expand to full width (100%)
  - Event details, RSVP section, and action buttons center and stack properly
  - 80px top padding added to prevent topbar overlap

- **General Mobile Fixes**:
  - Career profile edit page responsive layout
  - Proper spacing and centering for all mobile navigation items
  - No horizontal overflow on any page

## Related Issue

Resolves # (issue) N/A

## Steps to view & test changes:

1. **Career Profile**:
   - Navigate to your profile page
   - Click "Career Profile" button or use Career Hub tab in navigation
   - Click "Edit" to open the career profile form
   - Fill out bio, add skills and career interests (press Enter to add tags)
   - Add professional links (LinkedIn, GitHub, etc.)
   - Toggle privacy settings
   - Save changes and verify they persist after refresh
   - Return to Career Hub to see profile preview

2. **Mobile Responsiveness** (test at 375px width):
   - Open Career Hub - verify 2/3-1/3 layout becomes single column
   - Verify 4 cards stack vertically without horizontal overflow
   - Open hamburger menu - verify Profile, Admin View (if admin), and Sign Out appear
   - Verify profile dropdown is hidden on mobile
   - Navigate to Events page in admin view - verify event tiles stack properly
   - Test Career Hub - verify no content is hidden behind topbar

3. **Navigation Flow**:
   - Test: Profile page → Career Hub tab → Edit button → Back to Profile
   - Test: Career Hub → Edit → Back to Career Hub
   - Verify all back buttons and navigation links work correctly

4. **Desktop Layout** (test at 1440px width):
   - Career Hub shows 2/3 left column (4 cards in 2x2 grid) + 1/3 right column (profile preview)
   - Profile preview stays sticky while scrolling
   - All topbar navigation items visible

## How Has This Been Tested?

- [x] Manual tests
- [x] Responsive View

## Screenshots (if appropriate)

**Career Hub Landing Page (Desktop)**
- Shows 2/3-1/3 split with action cards and profile preview

<img width="1872" height="918" alt="image" src="https://github.com/user-attachments/assets/630dcf48-f617-4c69-aaef-4c02e9e2b61e" />


<img width="669" height="886" alt="image" src="https://github.com/user-attachments/assets/8df77655-8965-44fd-ae63-a41e6bf057f3" />


**Career Profile Edit Form**
- Profile completeness tracker
- Tag-based skills/interests input
- All form fields with validation

<img width="1855" height="918" alt="image" src="https://github.com/user-attachments/assets/f626186e-7387-4ab8-8015-9d9473f28abd" />


<img width="397" height="837" alt="image" src="https://github.com/user-attachments/assets/2944cb92-9b36-4a15-bd9a-1878cd2464e5" />
<img width="394" height="836" alt="image" src="https://github.com/user-attachments/assets/7e1bdfb1-0592-4c0a-838f-24974ed81f24" />


**Mobile View - Topbar Menu**
- Hamburger menu with Profile, Admin View, Sign Out
- No profile dropdown visible
<img width="387" height="358" alt="image" src="https://github.com/user-attachments/assets/691973d0-eb97-4c61-a583-c3ba0c0cd019" />


**Admin Events - Mobile**
- Event tiles stacked vertically
- Full-width cover images
- Centered event details

<img width="390" height="840" alt="image" src="https://github.com/user-attachments/assets/7ed530e7-5b6b-4060-8757-225925eb49b8" />
