### PR TITLE
remove nginx (handled by caddy on OCI gateway now)

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -28,72 +28,31 @@ http {
 	server {
 		listen 80;
 		listen [::]:80;
-		
 		server_name members.uclaacm.com;
-		return 301 https://$host$request_uri;
-	}
-
-	server {
-		listen 443 ssl http2;
-		listen [::]:443;
-
-		server_name members.uclaacm.com
-
 		sendfile on;
 		expires $expires;
-
-		ssl on;
-		add_header                Strict-Transport-Security "max-age=31536000" always;
-		ssl_session_cache         shared:SSL:20m;
-		ssl_session_timeout       10m;
-
-		ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
-		ssl_prefer_server_ciphers on;
-		ssl_ciphers               "ECDH+AESGCM:ECDH+AES256:ECDH+AES128:!ADH:!AECDH:!MD5;";
-
-		resolver                  8.8.8.8 8.8.4.4;
-		ssl_stapling              on;
-		ssl_stapling_verify       on;
-
-		ssl_certificate           /etc/nginx/certs/live/members.uclaacm.com/fullchain.pem;
-		ssl_certificate_key       /etc/nginx/certs/live/members.uclaacm.com/privkey.pem;
-		ssl_trusted_certificate   /etc/nginx/certs/live/members.uclaacm.com/chain.pem;
-
-		reset_timedout_connection on;
-		client_body_timeout       10;
-		send_timeout              5;
-		
-		keepalive_requests 100000;
-		keepalive_timeout  60;
-		tcp_nodelay on;
-		tcp_nopush  on;
-
 		location /app {
 			include /etc/nginx/gzip.conf;
-
 			proxy_set_header Host $host;
 			proxy_set_header X-Forwarded-For $remote_addr;
 			proxy_pass http://api_server;
 		}
-
 		location ^~ /.well-known {
 			allow all;
 			root /data/letsencrypt;
 		}
-
 		location / {
 			include /etc/nginx/gzip.conf;
-
 			open_file_cache max=2000 inactive=10m;
 			open_file_cache_valid 5m;
 			open_file_cache_min_uses 2;
 			open_file_cache_errors off;
-
 			root /var/www/membership/static;
 			index index.html;
 			include /etc/nginx/mime.types;
-
 			try_files $uri $uri/ /index.html =404;
 		}
 	}
+	# SSL server block removed; SSL handled by gateway
+
 }

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ export default {
   google: {
     apiKey: process.env.GOOGLE_API_KEY,
     authDomain: process.env.GOOGLE_AUTH_DOMAIN,
-    clientId: '913307270840-751ad0psdu1q2a7m81np30g062osgpp5.apps.googleusercontent.com',
+    clientId: process.env.GOOGLE_CLIENT_ID,
     hostedDomain: 'g.ucla.edu',
   },
   routes: {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removes Nginx, SSH certs to be handled by Caddy on the OCI gateway. This will remove the need to renew certs every 3 months. Membership portal to be moved to self-hosted hardware.

## Related Issue

Resolves # (issue)
Related PR: https://github.com/uclaacm/membership-portal/pull/106
https://github.com/uclaacm/membership-portal-deployment/pull/14

## Steps to view & test changes:

- 

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
