### PR TITLE
Fix the z-index to render dropdown properly

### DIFF
--- a/src/components/Events/style.scss
+++ b/src/components/Events/style.scss
@@ -64,10 +64,10 @@
 
   .checkin-button {
     position: fixed;
-    top: 80px; 
+    top: 80px;
     top: 80px;
     right: 20px;
-    z-index: 10;
+    z-index: 8;
   }
 
   h1 {


### PR DESCRIPTION
## Description

Fix the z-index to render dropdown properly

## Related Issue

Resolves #213

## Steps to view & test changes:

- Run the app and go to events and click the dropdown

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="243" height="234" alt="image" src="https://github.com/user-attachments/assets/d691dd3b-bb44-4339-a7c3-6e5ce202d1f9" />
