### PR TITLE
Removed "View raw JSON" button from each events card

### DIFF
--- a/src/components/Events/AdminEvents/event.jsx
+++ b/src/components/Events/AdminEvents/event.jsx
@@ -168,10 +168,6 @@ class AdminEventCard extends React.Component {
                 ))}
               </div>
             )}
-            <details className="json-toggle">
-              <summary>View Raw JSON</summary>
-              <pre>{JSON.stringify({ error: null, rsvps: rsvpData }, null, 2)}</pre>
-            </details>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removed the "View Raw JSON" Button under each Events card. Applies to all role views: member, officer, admin (but only admin is relevant).

## Related Issue

Resolves #218 

## Steps to View & Test Changes:

- Run membership portal according to the [documentation](https://wiki.uclaacm.com/doc/membership-portal-zXucs8mbPS), set permissions to ADMIN to view the changes (steps at the bottom of the page).

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="1199" height="760" alt="image" src="https://github.com/user-attachments/assets/6b56ae1b-e422-4751-b202-11fab12fc066" />
