### PR TITLE
fix: <p> tag in Event description #215

### DIFF
--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -164,7 +164,7 @@ class EventCard extends React.Component {
                                 </button>
                                 <h3>{event.title}</h3>
                                 <div className="description-scroll">
-                                    <p style={{ whiteSpace: 'pre-wrap'}}>{this.getPlainTextDescription(event.description)}</p>
+                                    <p>{this.getPlainTextDescription(event.description)}</p>
                                 </div>
                             </div>
                         </div>

--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -86,10 +86,22 @@ class EventCard extends React.Component {
 
     getPlainTextDescription(description) {
         // Strips HTML tags while preserving basic formatting (line breaks)
-        if (!description) return '';
+        if (description == null) return '';
         if (typeof description !== 'string') return String(description);
-        const withLineBreaks = description.replace(/<\s*br\s*\/?\s*>/gi, '\n').replace(/<\s*\/\s*p\s*>/gi, '\n\n').replace(/<\s*\/\s*div\s*>/gi, '\n\n');
-        return withLineBreaks.replace(/<[^>]*>/g, '').replace(/\n{3,}/g, '\n\n').trim();
+        const withLineBreaks = description
+            .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+            .replace(/<\s*\/\s*p\s*>/gi, '\n\n')
+            .replace(/<\s*\/\s*div\s*>/gi, '\n\n');
+
+        if (typeof DOMParser === 'undefined') {
+            return withLineBreaks.replace(/\n{3,}/g, '\n\n').trim();
+        }
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(withLineBreaks, 'text/html');
+        const plainText = doc.body.textContent || '';
+
+        return plainText.replace(/\n{3,}/g, '\n\n').trim();
     }
 
     render() {

--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -84,6 +84,14 @@ class EventCard extends React.Component {
         this.setState({ loading: false });
     }
 
+    getPlainTextDescription(description) {
+        // Strips HTML tags while preserving basic formatting (line breaks)
+        if (!description) return '';
+        if (typeof description !== 'string') return String(description);
+        const withLineBreaks = description.replace(/<\s*br\s*\/?\s*>/gi, '\n').replace(/<\s*\/\s*p\s*>/gi, '\n\n').replace(/<\s*\/\s*div\s*>/gi, '\n\n');
+        return withLineBreaks.replace(/<[^>]*>/g, '').replace(/\n{3,}/g, '\n\n').trim();
+    }
+
     render() {
         const { event } = this.props;
         const { isRsvped, loading, isFlipped } = this.state;
@@ -144,7 +152,7 @@ class EventCard extends React.Component {
                                 </button>
                                 <h3>{event.title}</h3>
                                 <div className="description-scroll">
-                                    <p>{event.description}</p>
+                                    <p style={{ whiteSpace: 'pre-wrap'}}>{this.getPlainTextDescription(event.description)}</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixed <p> tag appearing in event description by introducing a helper function to remove any raw HTML tags from description.
## Related Issue

Resolves #215 

## Steps to view & test changes:

- checkout fix/event-p-tag
- run make, test on local host. Click on an event, all raw HTML tags should have disappeared

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
From localhost:
<img width="789" height="402" alt="Screenshot 2026-04-03 at 1 22 37 PM" src="https://github.com/user-attachments/assets/3d3bb2c9-052d-493c-b4dc-1806b4f7fef7" />
