### PR TITLE
Fix/officer control panel

### DIFF
--- a/src/components/ControlPanel/controlPanel.jsx
+++ b/src/components/ControlPanel/controlPanel.jsx
@@ -87,6 +87,12 @@ class ControlPanel extends React.Component {
     this.props.changeOneClickPassword(oldPassword, newPassword);
   };
 
+  extractImageUuidFromCover = (cover) => {
+    if (!cover || typeof cover !== 'string') return null;
+    const match = cover.match(/\/image\/raw\/([0-9a-f-]{36})/i);
+    return match ? match[1] : null;
+  };
+
   render() {
     const {
       logout, events, admins, images, isSuperAdmin, isOfficer, isAdmin,
@@ -111,9 +117,8 @@ class ControlPanel extends React.Component {
 
     const allowedImageUuids = new Set(
       visibleEvents
-        .map((event) => (event.cover || '').match(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i))
-        .filter(Boolean)
-        .map((match) => match[0]),
+        .map((event) => this.extractImageUuidFromCover(event.cover))
+        .filter(Boolean),
     );
 
     const visibleImages = isCommitteeScopedOfficer
@@ -179,7 +184,7 @@ class ControlPanel extends React.Component {
 
             <div className="panel-card">
               <span className="card-title">Images</span>
-              <span className="card-desc">Remove images used across the portal.</span>
+              <span className="card-desc">Remove uploaded portal images linked to event covers. External image URLs are not listed here.</span>
               <Button color="red" text="Manage Images" onClick={this.openImagesModal} />
             </div>
 

--- a/src/components/ControlPanel/controlPanel.jsx
+++ b/src/components/ControlPanel/controlPanel.jsx
@@ -184,7 +184,7 @@ class ControlPanel extends React.Component {
 
             <div className="panel-card">
               <span className="card-title">Images</span>
-              <span className="card-desc">Remove uploaded portal images linked to event covers. External image URLs are not listed here.</span>
+              <span className="card-desc">Remove uploaded portal images. </span>
               <Button color="red" text="Manage Images" onClick={this.openImagesModal} />
             </div>
 

--- a/src/components/ControlPanel/controlPanel.jsx
+++ b/src/components/ControlPanel/controlPanel.jsx
@@ -89,9 +89,11 @@ class ControlPanel extends React.Component {
 
   render() {
     const {
-      logout, events, admins, images, isSuperAdmin, isOfficer,
+      logout, events, admins, images, isSuperAdmin, isOfficer, isAdmin,
+      officerCommittees,
       userEmail, adminView, toggleAdminView,
       oneClickUpdated, oneClickUpdateSuccess, oneClickError,
+      eventDeleteError, imageDeleteError,
     } = this.props;
 
     const {
@@ -102,8 +104,42 @@ class ControlPanel extends React.Component {
       showOneClickPasswordModal,
     } = this.state;
 
+    const isCommitteeScopedOfficer = isOfficer && !isAdmin;
+    const visibleEvents = isCommitteeScopedOfficer
+      ? events.filter((event) => officerCommittees.includes(event.committee))
+      : events;
+
+    const allowedImageUuids = new Set(
+      visibleEvents
+        .map((event) => (event.cover || '').match(/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i))
+        .filter(Boolean)
+        .map((match) => match[0]),
+    );
+
+    const visibleImages = isCommitteeScopedOfficer
+      ? images.filter((image) => allowedImageUuids.has(image.uuid))
+      : images;
+
+    const deleteErrorMessage = eventDeleteError || imageDeleteError;
+    let roleMessage = 'You are signed in as a member.';
+    if (isAdmin) {
+      roleMessage = 'You are signed in as admin';
+    } else if (isOfficer) {
+      if (officerCommittees.length > 0) {
+        roleMessage = `You are signed in as an Officer for ${officerCommittees.join(', ')}`;
+      } else {
+        roleMessage = 'You are signed in as an Officer';
+      }
+    }
+
     return (
       <div className="control-panel-wrapper">
+        <BannerMessage
+          showing={!!deleteErrorMessage}
+          success={false}
+          message={deleteErrorMessage}
+        />
+
         <BannerMessage
           showing={oneClickUpdated}
           success={oneClickUpdateSuccess}
@@ -112,6 +148,7 @@ class ControlPanel extends React.Component {
 
         <h1 className="DisplayPrimary panel-title">Control Panel</h1>
         <p className="panel-subtitle">Manage events, members, and portal settings.</p>
+  <p className="panel-subtitle">{roleMessage}</p>
 
         <div className="panel-section">
           <h2 className="section-title">User Management</h2>
@@ -183,14 +220,14 @@ class ControlPanel extends React.Component {
         {/* Modals */}
         <EventsModal
           opened={showEventsModal}
-          events={events}
+          events={visibleEvents}
           onDelete={this.openEventsConfirmationModal}
           onClose={this.closeEventsModal}
         />
 
         <ImagesModal
           opened={showImagesModal}
-          images={images}
+          images={visibleImages}
           onDelete={this.openImagesConfirmationModal}
           onClose={this.closeImagesModal}
         />
@@ -259,9 +296,12 @@ class ControlPanel extends React.Component {
 }
 
 ControlPanel.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
   isOfficer: PropTypes.bool.isRequired,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string).isRequired,
   logout: PropTypes.func.isRequired,
   deleteEvent: PropTypes.func.isRequired,
+  deleteImage: PropTypes.func.isRequired,
   removeAdmin: PropTypes.func.isRequired,
   reassignAdmin: PropTypes.func.isRequired,
   addAdmin: PropTypes.func.isRequired,
@@ -274,6 +314,8 @@ ControlPanel.propTypes = {
   oneClickUpdated: PropTypes.bool.isRequired,
   oneClickUpdateSuccess: PropTypes.bool.isRequired,
   oneClickError: PropTypes.string.isRequired,
+  eventDeleteError: PropTypes.string,
+  imageDeleteError: PropTypes.string,
   adminView: PropTypes.bool.isRequired,
   toggleAdminView: PropTypes.func.isRequired,
 };

--- a/src/components/ControlPanel/controlPanel.jsx
+++ b/src/components/ControlPanel/controlPanel.jsx
@@ -147,8 +147,7 @@ class ControlPanel extends React.Component {
         />
 
         <h1 className="DisplayPrimary panel-title">Control Panel</h1>
-        <p className="panel-subtitle">Manage events, members, and portal settings.</p>
-  <p className="panel-subtitle">{roleMessage}</p>
+        <p className="panel-subtitle">Manage events, members, and portal settings. {roleMessage}</p>
 
         <div className="panel-section">
           <h2 className="section-title">User Management</h2>

--- a/src/components/ControlPanel/index.jsx
+++ b/src/components/ControlPanel/index.jsx
@@ -7,12 +7,15 @@ import ControlPanel from './controlPanel';
 export default class ControlPanelComponent extends React.Component {
   render() {
     const {
+      isAdmin,
+      isOfficer,
       logout,
       userEmail,
       events,
       deleteEvent,
       images,
       deleteImage,
+      officerCommittees,
       admins,
       removeAdmin,
       addAdmin,
@@ -22,6 +25,8 @@ export default class ControlPanelComponent extends React.Component {
       oneClickUpdated,
       oneClickUpdateSuccess,
       oneClickError,
+      eventDeleteError,
+      imageDeleteError,
       adminView,
       toggleAdminView,
     } = this.props;
@@ -30,12 +35,15 @@ export default class ControlPanelComponent extends React.Component {
         <Topbar />
         {/* <Sidebar /> */}
         <ControlPanel
+          isAdmin={isAdmin}
+          isOfficer={isOfficer}
           logout={logout}
           userEmail={userEmail}
           events={events}
           deleteEvent={deleteEvent}
           images={images}
           deleteImage={deleteImage}
+          officerCommittees={officerCommittees}
           admins={admins}
           removeAdmin={removeAdmin}
           addAdmin={addAdmin}
@@ -45,6 +53,8 @@ export default class ControlPanelComponent extends React.Component {
           oneClickUpdated={oneClickUpdated}
           oneClickUpdateSuccess={oneClickUpdateSuccess}
           oneClickError={oneClickError}
+          eventDeleteError={eventDeleteError}
+          imageDeleteError={imageDeleteError}
           adminView={adminView}
           toggleAdminView={toggleAdminView}
         />
@@ -54,6 +64,8 @@ export default class ControlPanelComponent extends React.Component {
 }
 
 ControlPanelComponent.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
+  isOfficer: PropTypes.bool.isRequired,
   logout: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,
   events: PropTypes.arrayOf(PropTypes.shape({
@@ -64,6 +76,7 @@ ControlPanelComponent.propTypes = {
     uuid: PropTypes.string,
   })).isRequired,
   deleteImage: PropTypes.func.isRequired,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string).isRequired,
   admins: PropTypes.arrayOf(PropTypes.shape({
     email: PropTypes.string,
   })).isRequired,
@@ -75,6 +88,8 @@ ControlPanelComponent.propTypes = {
   oneClickUpdated: PropTypes.bool.isRequired,
   oneClickUpdateSuccess: PropTypes.bool.isRequired,
   oneClickError: PropTypes.string.isRequired,
+  eventDeleteError: PropTypes.string,
+  imageDeleteError: PropTypes.string,
   adminView: PropTypes.bool.isRequired,
   toggleAdminView: PropTypes.func.isRequired,
 };

--- a/src/components/Events/AdminEvents/adminAddEvent.js
+++ b/src/components/Events/AdminEvents/adminAddEvent.js
@@ -74,19 +74,28 @@ export default class AdminAddEvent extends React.Component {
     }
 
     const callback = () => { if (this.props.onClickAdd) this.props.onClickAdd(this.state.event); };
+    const selectedFile = this.coverUploadRef.current
+      && this.coverUploadRef.current.files
+      && this.coverUploadRef.current.files[0]
+      ? this.coverUploadRef.current.files[0]
+      : this.state.coverImageFile;
 
-    if (this.state.coverImageFile) {
+    if (selectedFile) {
       const formData = new FormData();
-      formData.append('image', this.state.coverImageFile);
+      formData.append('image', selectedFile);
 
       const uploadResult = await this.props.createImage(formData);
       if (!uploadResult || !uploadResult.success || !uploadResult.uuid) {
+        this.setState({
+          coverUrlError: 'Image upload failed. Please try again or use an image URL.',
+        });
         return;
       }
 
       this.setState((prev) => {
         const newState = Object.assign({}, prev);
         newState.event.cover = `${Config.API_URL + Config.routes.image.specific}/${uploadResult.uuid}`;
+        newState.coverUrlError = '';
         return newState;
       }, callback);
     } else {
@@ -131,19 +140,18 @@ export default class AdminAddEvent extends React.Component {
         return;
       }
 
-      const reader = new FileReader();
-      reader.onloadend = () => {
+      const localPreviewUrl = (window.URL && window.URL.createObjectURL)
+        ? window.URL.createObjectURL(file)
+        : this.state.event.cover;
 
-        this.setState((prev) => {
-          const newState = Object.assign({}, prev);
-          newState.event.cover = reader.result;       // don't freak out, this is temporary/local-only until handleSubmit
-          newState.coverImageFile = file;
-          newState.coverUrlError = '';
-          return newState;
-        });
-
-      };
-      reader.readAsDataURL(file);
+      this.setState((prev) => {
+        const newState = Object.assign({}, prev);
+        // Local preview only; persisted cover URL is set after successful upload.
+        newState.event.cover = localPreviewUrl;
+        newState.coverImageFile = file;
+        newState.coverUrlError = '';
+        return newState;
+      });
     }
   }
 

--- a/src/components/Events/AdminEvents/adminAddEvent.js
+++ b/src/components/Events/AdminEvents/adminAddEvent.js
@@ -13,7 +13,13 @@ import 'react-datepicker/dist/react-datepicker.css';
 export default class AdminAddEvent extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { event: this.props.event, startTimeError: false, endTimeError: false, coverImageFile: null };
+    this.state = {
+      event: this.props.event,
+      startTimeError: false,
+      endTimeError: false,
+      coverImageFile: null,
+      coverUrlError: '',
+    };
     this.coverUploadRef = createRef();
     this.resizeTextArea = this.resizeTextArea.bind(this);
     this.handleChangeCover = this.handleChangeCover.bind(this);
@@ -56,8 +62,16 @@ export default class AdminAddEvent extends React.Component {
     });
   }
 
-  handleSubmit() {
+  async handleSubmit() {
     if (this.state.endTimeError || this.state.startTimeError) return;
+
+    const coverUrl = this.state.event.cover || '';
+    if (!this.state.coverImageFile && coverUrl.length > 2048) {
+      this.setState({
+        coverUrlError: 'Image URL is too long. Please keep it under 2048 characters or upload a file.',
+      });
+      return;
+    }
 
     const callback = () => { if (this.props.onClickAdd) this.props.onClickAdd(this.state.event); };
 
@@ -65,23 +79,16 @@ export default class AdminAddEvent extends React.Component {
       const formData = new FormData();
       formData.append('image', this.state.coverImageFile);
 
-      let oldImageCreateUuid = this.props.imageCreateUuid;
-      let retries = 0;
-      let interval;
-      this.props.createImage(formData)
+      const uploadResult = await this.props.createImage(formData);
+      if (!uploadResult || !uploadResult.success || !uploadResult.uuid) {
+        return;
+      }
 
-      interval = setInterval(() => {
-        if (retries > 5 || this.props.imageCreateUuid !== oldImageCreateUuid) {
-          clearInterval(interval);
-          this.setState((prev) => {
-            const newState = Object.assign({}, prev);
-            newState.event.cover = `${Config.API_URL + Config.routes.image.specific}/${this.props.imageCreateUuid}`;
-            return newState;
-          }, callback);
-        } else {
-          retries += 1;
-        }
-      }, 500);
+      this.setState((prev) => {
+        const newState = Object.assign({}, prev);
+        newState.event.cover = `${Config.API_URL + Config.routes.image.specific}/${uploadResult.uuid}`;
+        return newState;
+      }, callback);
     } else {
       callback();
     }
@@ -114,6 +121,7 @@ export default class AdminAddEvent extends React.Component {
         const newState = Object.assign({}, prev);
         newState.event.cover = e.target.value;
         newState.coverImageFile = null;
+        newState.coverUrlError = '';
         return newState;
       });
     } else {
@@ -130,6 +138,7 @@ export default class AdminAddEvent extends React.Component {
           const newState = Object.assign({}, prev);
           newState.event.cover = reader.result;       // don't freak out, this is temporary/local-only until handleSubmit
           newState.coverImageFile = file;
+          newState.coverUrlError = '';
           return newState;
         });
 
@@ -143,6 +152,16 @@ export default class AdminAddEvent extends React.Component {
       const newState = Object.assign({}, prev);
       newState.event = nextProps.event;
       if (newState.event) newState.event.attendanceCode = nextProps.event.attendanceCode || '';
+
+      const isOfficerCreateMode = nextProps.isOfficer && !nextProps.isAdmin && !nextProps.isEdit;
+      if (isOfficerCreateMode && nextProps.officerCommittees.length > 0) {
+        const allowedCommittees = nextProps.officerCommittees;
+        const currentCommittee = newState.event.committee;
+        if (!allowedCommittees.includes(currentCommittee)) {
+          newState.event.committee = allowedCommittees[0];
+        }
+      }
+
       return newState;
     });
   }
@@ -155,6 +174,11 @@ export default class AdminAddEvent extends React.Component {
 
   render() {
     const committeeColorMap = Object.fromEntries(Config.committeeColors);
+    const isOfficerCreateMode = this.props.isOfficer && !this.props.isAdmin && !this.props.isEdit;
+    const committeeOptions = isOfficerCreateMode
+      ? this.props.officerCommittees
+      : ['ACM', ...Config.committees];
+    const committeeSelectDisabled = isOfficerCreateMode;
 
     return (
       <div className={`add-event-overlay${this.props.showing ? ' showing' : ''}`} onClick={this.props.onClickCancel}>
@@ -182,6 +206,7 @@ export default class AdminAddEvent extends React.Component {
               <div className="input-field half-width">
                 <p>Image URL or Upload</p>
                 <input type="text" value={this.state.event.cover} name="cover" onChange={this.handleChangeCover} />
+                {this.state.coverUrlError && <p className="error">{this.state.coverUrlError}</p>}
               </div>
               <div className="input-field one-fourth-width file-upload">
                 <input type="file" value={''} name="cover" ref={this.coverUploadRef} id="coverInput" accept="image/*" onChange={this.handleChangeCover} onClick={(event) => { event.target.value = null }} />
@@ -207,9 +232,9 @@ export default class AdminAddEvent extends React.Component {
                   onChange={this.handleChange}
                   className="committee-select"
                   style={{ color: committeeColorMap[this.state.event.committee] }}
+                  disabled={committeeSelectDisabled}
                 >
-                  <option value="ACM">ACM</option>
-                  {Config.committees.map((committee, index) => (
+                  {committeeOptions.map((committee, index) => (
                     <option key={index} value={committee}>
                       {committee}
                     </option>
@@ -313,6 +338,9 @@ AdminAddEvent.propTypes = {
   onClickSync: PropTypes.func,
   isEdit: PropTypes.bool,
   showing: PropTypes.bool,
+  isAdmin: PropTypes.bool,
+  isOfficer: PropTypes.bool,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string),
 };
 
 AdminAddEvent.defaultProps = {
@@ -321,4 +349,7 @@ AdminAddEvent.defaultProps = {
   onClickSync: null,
   isEdit: false,
   showing: false,
+  isAdmin: false,
+  isOfficer: false,
+  officerCommittees: [],
 };

--- a/src/components/Events/AdminEvents/event.jsx
+++ b/src/components/Events/AdminEvents/event.jsx
@@ -18,8 +18,36 @@ class AdminEventCard extends React.Component {
     this.copyEmailsToClipboard = this.copyEmailsToClipboard.bind(this);
   }
 
+  canViewRsvps() {
+    const {
+      isAdmin,
+      isOfficer,
+      officerCommittees,
+      event,
+    } = this.props;
+
+    if (isAdmin) return true;
+    if (!isOfficer) return false;
+    return officerCommittees.includes(event.committee);
+  }
+
+  canEditEvent() {
+    const {
+      isAdmin,
+      isOfficer,
+      officerCommittees,
+      event,
+    } = this.props;
+
+    if (isAdmin) return true;
+    if (!isOfficer) return false;
+    return officerCommittees.includes(event.committee);
+  }
+
   async componentDidMount() {
     const { event, fetchEventRSVPs } = this.props;
+    if (!this.canViewRsvps()) return;
+
     // Fetch RSVPs when component mounts
     if (event && event.uuid) {
       const response = await fetchEventRSVPs(event.uuid);
@@ -33,6 +61,10 @@ class AdminEventCard extends React.Component {
     const { handleEditClick, event } = this.props;
     // Don't edit if clicking on the view RSVPs button
     if (e.target.closest('.view-rsvps-btn')) {
+      e.stopPropagation();
+      return;
+    }
+    if (!this.canEditEvent()) {
       e.stopPropagation();
       return;
     }
@@ -58,6 +90,8 @@ class AdminEventCard extends React.Component {
     const { fetchEventRSVPs, event } = this.props;
     const { showRsvpData } = this.state;
     e.stopPropagation(); // Prevent the edit event from firing
+
+    if (!this.canViewRsvps()) return;
 
     if (showRsvpData) {
       // Hide the data
@@ -89,8 +123,11 @@ class AdminEventCard extends React.Component {
     } = this.state;
 
     let buttonText = 'View All RSVPs';
+    const canViewRsvps = this.canViewRsvps();
     if (loading) {
       buttonText = 'Loading...';
+    } else if (!canViewRsvps) {
+      buttonText = 'RSVPs Restricted';
     } else if (showRsvpData) {
       buttonText = 'Hide RSVPs';
     }
@@ -116,7 +153,7 @@ class AdminEventCard extends React.Component {
               type="button"
               className="view-rsvps-btn"
               onClick={this.handleViewRsvps}
-              disabled={loading}
+              disabled={loading || !canViewRsvps}
             >
               {buttonText}
             </button>
@@ -184,6 +221,9 @@ AdminEventCard.propTypes = {
   }).isRequired,
   handleEditClick: PropTypes.func,
   fetchEventRSVPs: PropTypes.func.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+  isOfficer: PropTypes.bool.isRequired,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 AdminEventCard.defaultProps = {
@@ -192,6 +232,9 @@ AdminEventCard.defaultProps = {
 
 const mapStateToProps = state => ({
   eventRsvps: state.RSVP.get('eventRsvps'),
+  isAdmin: state.Auth.get('isAdmin'),
+  isOfficer: state.Auth.get('isOfficer'),
+  officerCommittees: (state.User.get('profile') && state.User.get('profile').committees) || [],
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Events/AdminEvents/index.js
+++ b/src/components/Events/AdminEvents/index.js
@@ -41,10 +41,17 @@ export default class AdminEvents extends React.Component {
 
   // Shows the add event sidebar
   showAddEvent(e) {
+    const officerDefaultCommittee = (!this.props.isAdmin && this.props.isOfficer && this.props.officerCommittees.length > 0)
+      ? this.props.officerCommittees[0]
+      : '';
+
     this.setState(prev => ({
       showAddEvent: true,
       isEditEvent: false,
-      eventPlaceholder: this.emptyEvent,
+      eventPlaceholder: {
+        ...this.emptyEvent,
+        committee: officerDefaultCommittee,
+      },
     }));
   }
 
@@ -155,6 +162,9 @@ export default class AdminEvents extends React.Component {
           showing={this.state.showAddEvent}
           createImage={this.props.createImage}
           imageCreateUuid={this.props.imageCreateUuid}
+          isAdmin={this.props.isAdmin}
+          isOfficer={this.props.isOfficer}
+          officerCommittees={this.props.officerCommittees}
         />
 
         {!this.state.showAddEvent && (
@@ -189,6 +199,9 @@ export default class AdminEvents extends React.Component {
 
 AdminEvents.propTypes = {
   events: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isAdmin: PropTypes.bool.isRequired,
+  isOfficer: PropTypes.bool.isRequired,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string).isRequired,
   error: PropTypes.string,
   created: PropTypes.bool,
   createSuccess: PropTypes.bool,

--- a/src/containers/controlPanel.jsx
+++ b/src/containers/controlPanel.jsx
@@ -48,17 +48,22 @@ class ControlPanel extends React.Component {
       removeAdmin,
       addAdmin,
       reassignAdmin,
+      isAdmin,
       isOfficer,
       isSuperAdmin,
+      officerCommittees,
       changeOneClickPassword,
       oneClickUpdated,
       oneClickUpdateSuccess,
       oneClickError,
+      eventDeleteError,
+      imageDeleteError,
       adminView,
       toggleAdminView,
     } = this.props;
     return (
       <ControlPanelComponent
+        isAdmin={isAdmin}
         isOfficer={isOfficer}
         logout={logout}
         userEmail={userEmail}
@@ -71,10 +76,13 @@ class ControlPanel extends React.Component {
         reassignAdmin={reassignAdmin}
         addAdmin={addAdmin}
         isSuperAdmin={isSuperAdmin}
+        officerCommittees={officerCommittees}
         changeOneClickPassword={changeOneClickPassword}
         oneClickUpdated={oneClickUpdated}
         oneClickUpdateSuccess={oneClickUpdateSuccess}
         oneClickError={oneClickError}
+        eventDeleteError={eventDeleteError}
+        imageDeleteError={imageDeleteError}
         adminView={adminView}
         toggleAdminView={toggleAdminView}
       />
@@ -82,20 +90,26 @@ class ControlPanel extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  userEmail: state.User.get('profile').email,
+const mapStateToProps = (state) => {
+  const profile = state.User.get('profile') || {};
+  return {
+    userEmail: profile.email,
   authenticated: state.Auth.get('authenticated'),
   isAdmin: state.Auth.get('isAdmin'),
   isSuperAdmin: state.Auth.get('isSuperAdmin'),
   isOfficer: state.Auth.get('isOfficer'),
+    officerCommittees: profile.committees || [],
   events: state.Events.get('events'),
   images: state.Images.get('images'),
+    eventDeleteError: state.Events.get('deleteError'),
+    imageDeleteError: state.Images.get('deleteError'),
   admins: state.Admins.get('admins'),
   oneClickUpdated: state.OneClick.get('updated'),
   oneClickUpdateSuccess: state.OneClick.get('updateSuccess'),
   oneClickError: state.OneClick.get('error'),
   adminView: state.Auth.get('adminView'),
-});
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   redirectHome: () => {
@@ -164,11 +178,15 @@ ControlPanel.propTypes = {
   removeAdmin: PropTypes.func.isRequired,
   addAdmin: PropTypes.func.isRequired,
   reassignAdmin: PropTypes.func.isRequired,
+  isAdmin: PropTypes.bool.isRequired,
   isSuperAdmin: PropTypes.bool.isRequired,
+  officerCommittees: PropTypes.arrayOf(PropTypes.string).isRequired,
   changeOneClickPassword: PropTypes.func.isRequired,
   oneClickUpdated: PropTypes.bool.isRequired,
   oneClickUpdateSuccess: PropTypes.bool.isRequired,
   oneClickError: PropTypes.string.isRequired,
+  eventDeleteError: PropTypes.string,
+  imageDeleteError: PropTypes.string,
   adminView: PropTypes.bool.isRequired,
   toggleAdminView: PropTypes.func.isRequired,
 };

--- a/src/containers/events.js
+++ b/src/containers/events.js
@@ -27,8 +27,8 @@ class Events extends React.Component {
   }
 
   render() {
-    // Only show admin view if user is admin AND adminView is true
-    const showAdminView = this.props.isAdmin && this.props.adminView;
+    // Show elevated events dashboard for admins and officers when adminView is enabled.
+    const showAdminView = (this.props.isAdmin || this.props.isOfficer) && this.props.adminView;
 
     return (
       <div>
@@ -69,6 +69,9 @@ class Events extends React.Component {
             createImage={this.props.createImage}
             imageCreateSuccess={this.props.imageCreateSuccess}
             imageCreateUuid={this.props.imageCreateUuid}
+            isAdmin={this.props.isAdmin}
+            isOfficer={this.props.isOfficer}
+            officerCommittees={this.props.officerCommittees}
           />
         )}
       </div>
@@ -77,6 +80,7 @@ class Events extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  profile: state.User.get('profile'),
   events: state.Events.get('events'),
   error: state.Events.get('error'),
   eventCreated: state.Events.get('posted'),
@@ -88,6 +92,8 @@ const mapStateToProps = state => ({
   syncMessage: state.Events.get('syncMessage'),
   authenticated: state.Auth.get('authenticated'),
   isAdmin: state.Auth.get('isAdmin'),
+  isOfficer: state.Auth.get('isOfficer'),
+  officerCommittees: (state.User.get('profile') && state.User.get('profile').committees) || [],
   adminView: state.Auth.get('adminView'),
   checkInSubmitted: state.CheckIn.get('submitted'),
   checkInPoints: state.CheckIn.get('numPoints'),

--- a/src/containers/events.js
+++ b/src/containers/events.js
@@ -164,7 +164,7 @@ const mapDispatchToProps = dispatch => ({
   },
 
   createImage: (formData) => {
-    dispatch(Action.CreateImage(formData));
+    return dispatch(Action.CreateImage(formData));
   },
 });
 

--- a/src/reducers/events.js
+++ b/src/reducers/events.js
@@ -30,6 +30,7 @@ const SYNC_EVENTS_DONE = Symbol();
 const defaultState = Immutable.fromJS({
   events: [],
   error: null,
+  deleteError: null,
   posted: false,
   updated: false,
   deleted: false,
@@ -207,12 +208,21 @@ const DeleteEvent = uuid => async (dispatch) => {
     });
 
     const status = await response.status;
-    if (status === 401 || status === 403) {
-      dispatch(LogoutUser());
+    if (status === 401) {
+      return dispatch(LogoutUser());
     }
 
     const data = await response.json();
     if (!data) throw new Error('Empty response from server');
+
+    if (status === 403) {
+      throw new Error((data.error && data.error.message) || 'You do not have permission to delete this event.');
+    }
+
+    if (status >= 400) {
+      throw new Error((data.error && data.error.message) || `Server error: ${status}`);
+    }
+    if (data.error) throw new Error(data.error.message);
 
     dispatch(State.DeleteEvent());
     dispatch(GetCurrentEvents());
@@ -309,7 +319,8 @@ const Events = (state = defaultState, action) => {
 
     case DELETE_EVENT_SUCCESS:
       return state.withMutations((val) => {
-        val.set('error', 'null');
+        val.set('error', null);
+        val.set('deleteError', null);
         val.set('deleted', true);
         val.set('deleteSuccess', true);
       });
@@ -317,6 +328,7 @@ const Events = (state = defaultState, action) => {
     case DELETE_EVENT_ERROR:
       return state.withMutations((val) => {
         val.set('error', action.error);
+        val.set('deleteError', action.error);
         val.set('deleted', true);
         val.set('deleteSuccess', false);
       });

--- a/src/reducers/image.js
+++ b/src/reducers/image.js
@@ -98,18 +98,26 @@ const CreateImage = formData => async (dispatch) => {
     });
 
     const status = await response.status;
-    if (status === 401 || status === 403) {
-      dispatch(LogoutUser());
+    if (status === 401) {
+      return dispatch(LogoutUser());
     }
 
     const data = await response.json();
     if (!data) throw new Error('Empty response from server');
+    if (status === 403) {
+      throw new Error((data.error && data.error.message) || 'You do not have permission to upload images.');
+    }
+    if (status >= 400) {
+      throw new Error((data.error && data.error.message) || `Server error: ${status}`);
+    }
     if (data.error) throw new Error(data.error.message);
 
     dispatch(State.CreateImage(null, data.uuid));
     dispatch(GetAllImages());
+    return { success: true, uuid: data.uuid };
   } catch (err) {
     dispatch(State.CreateImage(err.message));
+    return { success: false, error: err };
   }
 };
 

--- a/src/reducers/image.js
+++ b/src/reducers/image.js
@@ -102,7 +102,14 @@ const CreateImage = formData => async (dispatch) => {
       return dispatch(LogoutUser());
     }
 
-    const data = await response.json();
+    let data;
+    const text = await response.text();
+    try {
+      data = JSON.parse(text);
+    } catch (parseErr) {
+      throw new Error(`Invalid response format: ${text}`);
+    }
+    
     if (!data) throw new Error('Empty response from server');
     if (status === 403) {
       throw new Error((data.error && data.error.message) || 'You do not have permission to upload images.');
@@ -113,7 +120,14 @@ const CreateImage = formData => async (dispatch) => {
     if (data.error) throw new Error(data.error.message);
 
     dispatch(State.CreateImage(null, data.uuid));
-    dispatch(GetAllImages());
+    
+    // GetAllImages is async, make sure it completes
+    try {
+      await dispatch(GetAllImages());
+    } catch (err) {
+      // Don't fail the upload if image listing fails
+    }
+    
     return { success: true, uuid: data.uuid };
   } catch (err) {
     dispatch(State.CreateImage(err.message));

--- a/src/reducers/image.js
+++ b/src/reducers/image.js
@@ -20,6 +20,7 @@ const CREATE_IMAGE_ERROR = Symbol();
 const defaultState = Immutable.fromJS({
   images: [],
   error: null,
+  deleteError: null,
   created: false,
   deleted: false,
   createSuccess: false,
@@ -124,12 +125,21 @@ const DeleteImage = uuid => async (dispatch) => {
     });
 
     const status = await response.status;
-    if (status === 401 || status === 403) {
-      dispatch(LogoutUser());
+    if (status === 401) {
+      return dispatch(LogoutUser());
     }
 
     const data = await response.json();
     if (!data) throw new Error('Empty response from server');
+
+    if (status === 403) {
+      throw new Error((data.error && data.error.message) || 'You do not have permission to delete this image.');
+    }
+
+    if (status >= 400) {
+      throw new Error((data.error && data.error.message) || `Server error: ${status}`);
+    }
+    if (data.error) throw new Error(data.error.message);
 
     dispatch(State.DeleteImage());
     dispatch(GetAllImages());
@@ -173,7 +183,8 @@ const Images = (state = defaultState, action) => {
 
     case DELETE_IMAGE_SUCCESS:
       return state.withMutations((val) => {
-        val.set('error', 'null');
+        val.set('error', null);
+        val.set('deleteError', null);
         val.set('deleted', true);
         val.set('deleteSuccess', true);
       });
@@ -181,6 +192,7 @@ const Images = (state = defaultState, action) => {
     case DELETE_IMAGE_ERROR:
       return state.withMutations((val) => {
         val.set('error', action.error);
+        val.set('deleteError', action.error);
         val.set('deleted', true);
         val.set('deleteSuccess', false);
       });

--- a/tests/control-panel-delete-permissions.tests.jsx
+++ b/tests/control-panel-delete-permissions.tests.jsx
@@ -1,0 +1,60 @@
+import 'jest';
+
+import { DeleteEvent, Events } from 'reducers/events';
+import { DeleteImage, Images } from 'reducers/image';
+
+const makeJsonResponse = (status, body) => ({
+  status,
+  json: () => Promise.resolve(body),
+});
+
+describe('Control panel delete permission handling', () => {
+  afterEach(() => {
+    global.fetch = undefined;
+    jest.clearAllMocks();
+  });
+
+  test('DeleteEvent 403 dispatches permission error and does not dispatch logout thunk', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      makeJsonResponse(403, { error: { message: 'You do not have permission to delete this event.' } }),
+    );
+
+    const dispatch = jest.fn();
+    await DeleteEvent('event-uuid')(dispatch);
+
+    expect(dispatch).not.toHaveBeenCalledWith(expect.any(Function));
+
+    const errorAction = dispatch.mock.calls
+      .map(call => call[0])
+      .find(action => action && action.error);
+
+    expect(errorAction).toBeDefined();
+    expect(errorAction.error).toMatch(/permission/i);
+
+    const nextState = Events(undefined, errorAction);
+    expect(nextState.get('deleteSuccess')).toBe(false);
+    expect(nextState.get('deleteError')).toMatch(/permission/i);
+  });
+
+  test('DeleteImage 403 dispatches permission error and does not dispatch logout thunk', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      makeJsonResponse(403, { error: { message: 'You do not have permission to delete this image.' } }),
+    );
+
+    const dispatch = jest.fn();
+    await DeleteImage('image-uuid')(dispatch);
+
+    expect(dispatch).not.toHaveBeenCalledWith(expect.any(Function));
+
+    const errorAction = dispatch.mock.calls
+      .map(call => call[0])
+      .find(action => action && action.error);
+
+    expect(errorAction).toBeDefined();
+    expect(errorAction.error).toMatch(/permission/i);
+
+    const nextState = Images(undefined, errorAction);
+    expect(nextState.get('deleteSuccess')).toBe(false);
+    expect(nextState.get('deleteError')).toMatch(/permission/i);
+  });
+});


### PR DESCRIPTION
## Description

Fixed officer events view to match more cllosely with admin view
Officers can edit and only their committee’s events.
Officers cannot edit or reassign other committees’ events.
Admin behavior stays unchanged.

## Related Issue

Resolves #217 

## Steps to view & test changes:

- 

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
