### PR TITLE
fixed admin view "my profile" button #214

### DIFF
--- a/src/containers/profile.js
+++ b/src/containers/profile.js
@@ -15,11 +15,6 @@ class Profile extends React.Component {
   }
 
   componentWillMount() {
-    // Only redirect if admin is in admin view
-    const showAdminView = this.props.isAdmin && this.props.adminView;
-    if (showAdminView) {
-      return this.props.redirectHome();
-    }
     if (this.props.authenticated) {
       this.props.fetchUser();
       this.props.fetchActivity();
@@ -27,11 +22,6 @@ class Profile extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // Only redirect if admin is in admin view
-    const showAdminView = nextProps.isAdmin && nextProps.adminView;
-    if (showAdminView) {
-      return nextProps.redirectHome();
-    }
     if (nextProps.updated) {
       setTimeout(() => {
         this.props.updateDone();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removed redirect logic that was sending admins to home page instead of profile page
## Related Issue

Resolves #214 

## Steps to view & test changes:
- checkout fix/admin-my-profile-redirect
- test on local host, admin view. go to Home > Profile drop down > My Profile, should redirect to Profile page instead of Home.

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
