### PR TITLE
fix: visibility toggle + redirect on save

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     extends: "airbnb",
-    browser: true, 
     env: {
+        browser: true,
         jest: true,
     },
     settings: {

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -206,7 +206,7 @@ export default class CareerProfile extends React.Component {
       this.setState({ saving: false, saveSuccess: true });
       setTimeout(() => {
         this.setState({ saveSuccess: false });
-        window.location.replace('/profile/career');
+        history.push('/profile/career');
       }, 2000);
     } catch (error) {
       this.setState({ saving: false, saveError: error.message || 'Failed to save changes' });

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -87,8 +87,6 @@ export default class CareerProfile extends React.Component {
         resumeUrl: this.props.profile.resumeUrl || '',
         skills: this.props.profile.skills || [],
         careerInterests: this.props.profile.careerInterests || [],
-        // Below line caused profile visibility toggle to reset, leading to confusion
-        // isProfilePublic: this.props.profile.isProfilePublic !== undefined ? this.props.profile.isProfilePublic : true,
       });
     }
   }
@@ -209,7 +207,7 @@ export default class CareerProfile extends React.Component {
       setTimeout(() => {
         this.setState({ saveSuccess: false });
         window.location.replace('/profile/career');
-      }, 1000);
+      }, 2000);
     } catch (error) {
       this.setState({ saving: false, saveError: error.message || 'Failed to save changes' });
     }

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -87,7 +87,8 @@ export default class CareerProfile extends React.Component {
         resumeUrl: this.props.profile.resumeUrl || '',
         skills: this.props.profile.skills || [],
         careerInterests: this.props.profile.careerInterests || [],
-        isProfilePublic: this.props.profile.isProfilePublic !== undefined ? this.props.profile.isProfilePublic : true,
+        // Below line caused profile visibility toggle to reset, leading to confusion
+        // isProfilePublic: this.props.profile.isProfilePublic !== undefined ? this.props.profile.isProfilePublic : true,
       });
     }
   }
@@ -95,7 +96,7 @@ export default class CareerProfile extends React.Component {
   handleInputChange(e) {
     const { name, value } = e.target;
     this.setState({ [name]: value });
-    
+
     if (this.state.validationErrors[name]) {
       this.setState(prevState => ({
         validationErrors: { ...prevState.validationErrors, [name]: null },
@@ -170,20 +171,22 @@ export default class CareerProfile extends React.Component {
 
   async handleSubmit(e) {
     e.preventDefault();
-    
+
     const validationErrors = {};
     const linkedinError = getLinkedInUrlError(this.state.linkedinUrl);
     const githubError = getGitHubUrlError(this.state.githubUrl);
-    
+
     if (linkedinError) validationErrors.linkedinUrl = linkedinError;
     if (githubError) validationErrors.githubUrl = githubError;
-    
+
     if (Object.keys(validationErrors).length > 0) {
       this.setState({ validationErrors, saveError: 'Please fix the validation errors before saving.' });
       return;
     }
-    
-    this.setState({ saving: true, saveError: null, saveSuccess: false, validationErrors: {} });
+
+    this.setState({
+      saving: true, saveError: null, saveSuccess: false, validationErrors: {},
+    });
 
     const updates = {
       bio: this.state.bio,
@@ -203,7 +206,10 @@ export default class CareerProfile extends React.Component {
     try {
       await this.props.updateCareerProfile(updates);
       this.setState({ saving: false, saveSuccess: true });
-      setTimeout(() => this.setState({ saveSuccess: false }), 3000);
+      setTimeout(() => {
+        this.setState({ saveSuccess: false });
+        window.location.replace('/profile/career');
+      }, 1000);
     } catch (error) {
       this.setState({ saving: false, saveError: error.message || 'Failed to save changes' });
     }

--- a/src/components/Profile/CareerProfile.jsx
+++ b/src/components/Profile/CareerProfile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import './careerProfile.scss';
 
 const isValidLinkedInUrl = (url) => {
@@ -43,7 +43,7 @@ const getGitHubUrlError = (url) => {
   return null;
 };
 
-export default class CareerProfile extends React.Component {
+class CareerProfile extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -206,7 +206,7 @@ export default class CareerProfile extends React.Component {
       this.setState({ saving: false, saveSuccess: true });
       setTimeout(() => {
         this.setState({ saveSuccess: false });
-        history.push('/profile/career');
+        this.props.history.push('/profile/career');
       }, 2000);
     } catch (error) {
       this.setState({ saving: false, saveError: error.message || 'Failed to save changes' });
@@ -559,6 +559,8 @@ export default class CareerProfile extends React.Component {
     );
   }
 }
+
+export default withRouter(CareerProfile);
 
 CareerProfile.propTypes = {
   profile: PropTypes.object,


### PR DESCRIPTION
## Description

Fixes career profile visibility toggle not persisting toggled state on the frontend (plus a minor .eslintrc.js property fix)

## Related Issue

Resolves #224 

## Steps to view & test changes:

- Checkout latest `internship-main` on `membership-portal` & `membership-portal-deployment`
- Checkout `fix/career-toggle` on `membership-portal-ui`
- Run dev server
- Edit career profile & hit Save Changes

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
