### PR TITLE
Fix + Feat: Adding Checked In state for events and Syncing event RSVP UI with backend

### DIFF
--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -19,15 +19,60 @@ import moment from "moment";
       startTime: "",
 */
 class EventCard extends React.Component {
+    static EventCardState = {
+        AVAILABLE: 'AVAILABLE',          
+        RSVPED: 'RSVPED',                
+        LOADING: 'LOADING',               
+        CHECKED_IN: 'CHECKED_IN',        
+    };
+
     constructor(props) {
         super(props);
         this.state = {
             isRsvped: false,
             loading: false,
-            isFlipped: false
+            isFlipped: false,
+            isCheckInned: this.isEventCheckedIn(props),
         };
         this.handleRSVP = this.handleRSVP.bind(this);
         this.handleFlip = this.handleFlip.bind(this);
+    }
+
+    isEventCheckedIn(props = this.props) {
+        console.log('Checking if event is checked in with props:', props);
+        const { checkedInEvents, event } = props;
+        return checkedInEvents && checkedInEvents.has(event.uuid);
+    }
+
+    getEventCardState() {
+        if (this.state.isCheckInned) {
+            return EventCard.EventCardState.CHECKED_IN;
+        }
+        if (this.state.loading) {
+            return EventCard.EventCardState.LOADING;
+        }
+        if (this.state.isRsvped) {
+            return EventCard.EventCardState.RSVPED;
+        }
+        return EventCard.EventCardState.AVAILABLE;
+    }
+
+    getButtonText() {
+        const state = this.getEventCardState();
+        switch (state) {
+            case EventCard.EventCardState.CHECKED_IN:
+                return '✓ Checked In';
+            case EventCard.EventCardState.LOADING:
+                return 'Loading...';
+            case EventCard.EventCardState.RSVPED:
+                return 'Cancel RSVP';
+            default:
+                return 'RSVP';
+        }
+    }
+
+    isRSVPDisabled() {
+        return this.state.isCheckInned || this.state.loading;
     }
 
     handleFlip() {
@@ -41,12 +86,16 @@ class EventCard extends React.Component {
     }
 
     componentDidMount() {
-        // Fetch RSVPs when component mounts
         this.props.fetchUserRSVPs();
+        this.props.fetchCheckedInEvents();
     }
 
     componentDidUpdate(prevProps) {
-        // Check if this event is in the user's RSVPs
+        if (this.props.checkedInEvents !== prevProps.checkedInEvents) {
+            const isCheckInned = this.isEventCheckedIn();
+            this.setState({ isCheckInned });
+        }
+
         if (this.props.userRsvps !== prevProps.userRsvps) {
             this.checkRsvpStatus();
         }
@@ -61,6 +110,11 @@ class EventCard extends React.Component {
     }
     
     async handleRSVP() {
+        // Prevent RSVP action if checked in
+        if (this.state.isCheckInned) {
+            return;
+        }
+
         this.setState({ loading: true });
         
         try {
@@ -73,6 +127,7 @@ class EventCard extends React.Component {
             } else {
                 // Create RSVP
                 const result = await this.props.createRSVP(this.props.event.uuid);
+                console.log(result); 
                 if (result.success) {
                     this.setState({ isRsvped: true });
                 }
@@ -106,9 +161,10 @@ class EventCard extends React.Component {
 
     render() {
         const { event } = this.props;
-        const { isRsvped, loading, isFlipped } = this.state;
-
-        console.log(event.description);
+        const { isFlipped } = this.state;
+        const currentState = this.getEventCardState();
+        const buttonText = this.getButtonText();
+        const isDisabled = this.isRSVPDisabled();
 
         const committeeColorMap = Object.fromEntries(Config.committeeColors);
 
@@ -150,8 +206,17 @@ class EventCard extends React.Component {
                                     </a>
                                 </p>
                                 <p className="text" style={{color: committeeColorMap[event.committee]}}>{event.committee}</p>
-                                <div className={`pill-shape rsvp ${isRsvped ? 'rsvped' : ''} ${loading ? 'loading' : ''}`} onClick={this.handleRSVP}>
-                                    {loading ? 'Loading...' : isRsvped ? 'Cancel RSVP' : 'RSVP'}
+                                
+                                {/* RSVP Button with enum-based states */}
+                                <div 
+                                    className={`pill-shape rsvp ${currentState.toLowerCase()} ${isDisabled ? 'disabled' : ''}`}
+                                    onClick={this.handleRSVP}
+                                    style={{
+                                        opacity: isDisabled ? 0.6 : 1,
+                                        cursor: isDisabled ? 'not-allowed' : 'pointer',
+                                    }}
+                                >
+                                    {buttonText}
                                 </div>
                             </div>
                         </div>
@@ -176,11 +241,13 @@ class EventCard extends React.Component {
 }
 
 const mapStateToProps = state => ({
-    userRsvps: state.RSVP.get('userRsvps')
+    userRsvps: state.RSVP.get('userRsvps'),
+    checkedInEvents: state.CheckIn.get('checkedInEvents'),  
 });
 
 const mapDispatchToProps = dispatch => ({
     fetchUserRSVPs: () => dispatch(Action.FetchUserRSVPs()),
+    fetchCheckedInEvents: () => dispatch(Action.FetchCheckedInEvents()),  
     createRSVP: (eventUuid) => dispatch(Action.CreateRSVP(eventUuid)),
     cancelRSVP: (eventUuid) => dispatch(Action.CancelRSVP(eventUuid))
 });

--- a/src/components/Events/UserEvents/style.scss
+++ b/src/components/Events/UserEvents/style.scss
@@ -178,25 +178,33 @@
   background-color: rgba(30, 108, 255, 1);
   color: white;
   bottom: 0px;
-  right: 0px;
+  left: 0px;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   text-align: center;
   width: auto;
+  height: auto;
   text-wrap: nowrap;
-  margin-right: 14px;
+  margin-left: 0;
   margin-bottom: 14px;
+  padding: 8px 14px;
+  font-size: 14px;
+  font-weight: 400;
+  position: relative !important;
+  display: inline-flex !important;
+  justify-content: center !important;
+  align-items: center !important;
 
   &:hover {
     background-color: rgb(0, 41, 117);
   }
 
   &.rsvped {
-    background-color: #28a745;
-    padding: 0px 10px;
+    background-color: #dc3545;
+    padding: 8px 14px;
 
     &:hover {
-      background-color: #dc3545;
+      background-color: #8b0000;
     }
   }
 
@@ -207,6 +215,29 @@
     &:hover {
       background-color: #6c757d;
     }
+  }
+
+  &.checked_in {
+    background-color: #4caf50;
+
+    &:hover {
+      background-color: #45a049;
+    }
+  }
+
+  /* Mobile responsiveness */
+  @media (max-width: 600px) {
+    padding: 10px 16px;
+    font-size: 15px;
+    margin-left: 0;
+    margin-bottom: 10px;
+  }
+
+  @media (max-width: 400px) {
+    padding: 8px 12px;
+    font-size: 13px;
+    margin-left: 0;
+    margin-bottom: 8px;
   }
 }
 

--- a/src/components/Home/home.jsx
+++ b/src/components/Home/home.jsx
@@ -38,7 +38,6 @@ const Home = ({
   events,
 }) => {
   const handleSubmit = (e) => {
-    e.preventDefault();
     checkIn(e.target.attendanceCode.value);
   };
 

--- a/src/containers/home.jsx
+++ b/src/containers/home.jsx
@@ -17,6 +17,7 @@ class Home extends React.Component {
       fetchUser,
       fetchTime,
       fetchLeaderboard,
+      fetchCheckedInEvents,
     } = this.props;
 
     if (!authenticated) return;
@@ -24,6 +25,7 @@ class Home extends React.Component {
     fetchEvents();
     fetchImages();
     fetchUser();
+    fetchCheckedInEvents();
     if (Date.now() - fetchTime > REFRESH_INTERVAL) {
       fetchLeaderboard();
     }
@@ -110,6 +112,7 @@ Home.propTypes = {
   fetchImages: PropTypes.func.isRequired,
   fetchEvents: PropTypes.func.isRequired,
   fetchUser: PropTypes.func.isRequired,
+  fetchCheckedInEvents: PropTypes.func.isRequired,
   checkIn: PropTypes.func.isRequired,
   updateDone: PropTypes.func.isRequired,
   createDone: PropTypes.func.isRequired,
@@ -148,6 +151,7 @@ const mapDispatchToProps = dispatch => ({
   fetchUser: () => dispatch(Action.FetchUser()),
   checkIn: id => dispatch(Action.CheckInto(id)),
   resetCheckIn: () => dispatch(Action.ResetCheckIn()),
+  fetchCheckedInEvents: () => dispatch(Action.FetchCheckedInEvents()),  
   addEvent: event => dispatch(Action.PostNewEvent(event)),
   updateEvent: event => dispatch(Action.UpdateEvent(event)),
   updateDone: () => dispatch(Action.UpdateEventDone()),

--- a/src/reducers/checkin.js
+++ b/src/reducers/checkin.js
@@ -10,12 +10,19 @@ import { Action } from 'reducers';
 const CHECK_IN_SUCCESS = Symbol();
 const CHECK_IN_ERROR = Symbol();
 const CHECK_IN_RESET = Symbol();
+const FETCH_CHECKED_IN_EVENTS_SUCCESS = Symbol();
+const FETCH_CHECKED_IN_EVENTS_ERROR = Symbol();
+const ADD_CHECKED_IN_EVENT = Symbol();
 
 const defaultState = Immutable.fromJS({
+  // Last check-in attempt
   submitted: false,
   success: false,
   numPoints: 0,
   error: null,
+  
+  // All checked-in events for current user
+  checkedInEvents: Immutable.Set(),  // Set of event UUIDs
 });
 
 /** *********************************************
@@ -30,12 +37,57 @@ class State {
       error: error || undefined,
     };
   }
+
+  static FetchCheckedInEvents(error, eventUuids = []) {
+    return {
+      type: error ? FETCH_CHECKED_IN_EVENTS_ERROR : FETCH_CHECKED_IN_EVENTS_SUCCESS,
+      eventUuids,
+      error: error || undefined,
+    };
+  }
+
+  static AddCheckedInEvent(eventUuid) {
+    return {
+      type: ADD_CHECKED_IN_EVENT,
+      eventUuid,
+    };
+  }
 }
 
 /** *********************************************
  ** Actions                                   **
  ********************************************** */
 
+// Fetch all checked-in events for current user
+const FetchCheckedInEvents = () => async (dispatch) => {
+  try {
+    const response = await fetch(Config.API_URL + Config.routes.attendance.fetch, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${Storage.get('token')}`,
+      },
+    });
+
+    const status = await response.status;
+    if (status === 401 || status === 403) {
+      return dispatch(Action.LogoutUser());
+    }
+
+    const data = await response.json();
+    if (!data) throw new Error('Empty response from server');
+    if (data.error) throw new Error(data.error.message);
+
+    // Extract event UUIDs from attendance records
+    const eventUuids = data.attendance.map(record => record.event);
+    dispatch(State.FetchCheckedInEvents(null, eventUuids));
+  } catch (err) {
+    dispatch(State.FetchCheckedInEvents(err.message));
+  }
+};
+
+// Check in to an event (existing logic + add to local state)
 const CheckInto = attendanceCode => async (dispatch) => {
   try {
     const response = await fetch(Config.API_URL + Config.routes.attendance.attend, {
@@ -57,9 +109,12 @@ const CheckInto = attendanceCode => async (dispatch) => {
     if (!data) throw new Error('Empty response from server');
     if (data.error) throw new Error(data.error.message);
 
+    dispatch(State.AddCheckedInEvent(data.event.uuid));
+    
     dispatch(State.CheckIn(null, data.event.attendancePoints));
     dispatch(Action.FetchUser());
-    dispatch(Action.GetCurrentEvents());
+    
+    dispatch(Action.FetchCheckedInEvents())
   } catch (err) {
     dispatch(State.CheckIn(err.message));
   }
@@ -87,7 +142,21 @@ const CheckIn = (state = defaultState, action) => {
       });
 
     case CHECK_IN_RESET:
-      return defaultState;
+      return state.withMutations((val) => {
+        val.set('submitted', false);
+        val.set('success', false);
+        val.set('numPoints', 0);
+        val.set('error', null);
+      });
+
+    case FETCH_CHECKED_IN_EVENTS_SUCCESS:
+      return state.set('checkedInEvents', Immutable.Set(action.eventUuids));
+
+    case FETCH_CHECKED_IN_EVENTS_ERROR:
+      return state.set('error', action.error);
+
+    case ADD_CHECKED_IN_EVENT:
+      return state.update('checkedInEvents', set => set.add(action.eventUuid));
 
     default:
       return state;
@@ -96,4 +165,4 @@ const CheckIn = (state = defaultState, action) => {
 
 const ResetCheckIn = () => ({ type: CHECK_IN_RESET });
 
-export { CheckIn, CheckInto, ResetCheckIn };
+export { CheckIn, CheckInto, ResetCheckIn, FetchCheckedInEvents };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -31,7 +31,7 @@ import {
   SyncEventsDone,
 } from './events';
 import { Leaderboard, FetchLeaderboard, InvalidateLeaderboard } from './leaderboard';
-import { CheckIn, CheckInto, ResetCheckIn } from './checkin';
+import { CheckIn, CheckInto, ResetCheckIn, FetchCheckedInEvents } from './checkin';
 import { Registration, RegisterUser, registerDone } from './registration';
 import {
   Images, GetAllImages, CreateImage, DeleteImage,
@@ -88,6 +88,7 @@ const Action = {
   registerDone,
   CheckInto,
   ResetCheckIn,
+  FetchCheckedInEvents,
   CreateRSVP,
   CancelRSVP,
   FetchUserRSVPs,

--- a/src/reducers/rsvp.js
+++ b/src/reducers/rsvp.js
@@ -77,6 +77,10 @@ const CreateRSVP = eventUuid => async (dispatch) => {
       throw new Error(data.error || 'Failed to RSVP to event');
     }
 
+    if (data.error) {
+      throw new Error(data.error);
+    }
+
     dispatch(RSVPActions.RSVP(null, eventUuid));
     return { success: true };
   } catch (err) {
@@ -98,8 +102,14 @@ const CancelRSVP = eventUuid => async (dispatch) => {
 
     const data = await response.json();
 
+    console.log('Cancel RSVP response:', data);
+
     if (!response.ok) {
       throw new Error(data.error || 'Failed to cancel RSVP');
+    }
+
+    if (data.error) { 
+      throw new Error(data.error);
     }
 
     dispatch(RSVPActions.CancelRSVP(null, eventUuid));


### PR DESCRIPTION
## Description

References backend PR: https://github.com/uclaacm/membership-portal/pull/128

Fixes a bug where the UI would allow a user to "rsvp" for an event that has already started (visually). This pr fixes the issue by ensuring that if a user cannot rsvp for an event, e.g., the event has already started, then the rsvp button state will not update. 

To make it more clear when the user is allowed to rsvp, added a checked-in state for eventcards to disable the user from rsvp or canceling an rsvp when they have already checked in to an event 

## Related Issue

Resolves #220 

## Steps to view & test changes:
Testing Checked In state
- Create a new event on the current day and ends the next day with a join code
- join the event with the join code
- the joined event should have a disabled button field that says "checked in"

Testing that rsvp UI is synced with backend (database): 
- Create event that happens today at 00:00 (in the past) but does not end until the future (tmrw) 
- try to rsvp for event, it should not let you and switching to admin view should show no rsvp has been made for the event


## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="1910" height="897" alt="Screenshot 2026-04-06 at 9 04 00 PM" src="https://github.com/user-attachments/assets/9dc919b5-4345-4746-8d8a-edcfc37aea7d" />
