### PR TITLE
fix: keep external RSVP link white after visit

### DIFF
--- a/app/events/UserEvents/style.scss
+++ b/app/events/UserEvents/style.scss
@@ -196,7 +196,8 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
-.rsvp {
+.rsvp,
+.rsvp:visited {
   background-color: rgba(30, 108, 255, 1);
   color: white;
   text-decoration: none;


### PR DESCRIPTION
## Description

- Changed the RSVP button for cards on the Events Page so it no longer greys out after being clicked

<!--- Describe your changes in detail -->

## Related Issue

Resolves #290 

## Steps to view & test changes:

- Run the membership portal according to the documentation, navigate to the Events page, and click link on the card

## How Has This Been Tested?

- [x] Manual tests
- [x] Responsive View

## Screenshots (if appropriate)
<img width="1484" height="754" alt="image" src="https://github.com/user-attachments/assets/ee41113f-73e7-488e-a8aa-77cccbb2c122" />
