### PR TITLE
feat: implement fetchCommitteeById server action for internship committees

### DIFF
--- a/app/actions/internship/fetchCommitteeById.ts
+++ b/app/actions/internship/fetchCommitteeById.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import type { InternshipCommittee, FetchCommitteeByIdResult } from "@/lib/types/Internship";
+
+export default async function fetchCommitteeById(committeeId: string): Promise<FetchCommitteeByIdResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.committees}/${committeeId}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+    if (!data || data.error) return { success: false, error: data?.error?.message ?? "Failed to fetch committee." };
+
+    return { success: true, data: data.committee as InternshipCommittee };
+  } catch (error) {
+    Logger.error(`fetchCommitteeById failed: ${(error as Error).message}`);
+    return { success: false, error: "Failed to fetch committee." };
+  }
+}

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -16,3 +16,26 @@ export interface InternshipApplication {
 export type FetchApplicationByIdResult =
   | { success: true; data: InternshipApplication }
   | { success: false; error: string };
+
+export interface InternshipCommitteeQuestion {
+  questionKey: string;
+  questionText: string;
+  questionType: "short_text" | "long_text" | "multiple_choice";
+  required: boolean;
+  order: number;
+  choices: string[];
+}
+
+export interface InternshipCommittee {
+  id: string;
+  name: string;
+  displayName: string;
+  description?: string;
+  subcommittees: string[];
+  isActive: boolean;
+  internLimit?: number;
+  applicationDeadline?: string;
+  customQuestions: InternshipCommitteeQuestion[];
+}
+
+export type FetchCommitteeByIdResult = { success: true; data: InternshipCommittee } | { success: false; error: string };


### PR DESCRIPTION
…ails by ID

## Description

Implements the fetchCommitteeById server action under app/actions/internship/. The action accepts a committeeId string, validates the user's cookie-based auth token, calls GET /api/v1/internship/committees/:id, and returns a typed FetchCommitteeByIdResult discriminated union. Also adds the FetchCommitteeByIdResult type to lib/types/Internship.ts.

## Related Issue

Resolves #277

## Steps to view & test changes:

- Import and call fetchCommitteeById(committeeId) from a server component or another server action with a valid session cookie
- Verify it returns { success: true, data: InternshipCommittee } for a valid ID
- Verify it returns { success: false, error: "Not authenticated" } when no token cookie is present
- Verify it returns { success: false, error: "Failed to fetch committee." } for an invalid/nonexistent ID

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
N/A