### PR TITLE
feat: add fetchApplicationById server action 

### DIFF
--- a/app/actions/internship/fetchApplicationById.ts
+++ b/app/actions/internship/fetchApplicationById.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenOfficer } from "@/lib/token";
+import type { FetchApplicationByIdResult, InternshipApplication } from "@/lib/types/Internship";
+
+export default async function fetchApplicationById(applicationId: string): Promise<FetchApplicationByIdResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+    if (!isTokenOfficer(token!)) return { success: false, error: "Unauthorized" };
+
+    const response = await fetch(Config.API_URL + Config.routes.internship.applications + "/" + applicationId, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+    if (!data) throw new Error("Empty response from server");
+    if (data.error) return { success: false, error: data.error.message ?? "Failed to fetch application." };
+
+    return { success: true, data: data.application as InternshipApplication };
+  } catch (err) {
+    Logger.error(`fetchApplicationById failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application." };
+  }
+}

--- a/app/actions/internship/fetchCommitteeById.ts
+++ b/app/actions/internship/fetchCommitteeById.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import type { InternshipCommittee, FetchCommitteeByIdResult } from "@/lib/types/Internship";
+
+export default async function fetchCommitteeById(committeeId: string): Promise<FetchCommitteeByIdResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.committees}/${committeeId}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+    if (!data || data.error) return { success: false, error: data?.error?.message ?? "Failed to fetch committee." };
+
+    return { success: true, data: data.committee as InternshipCommittee };
+  } catch (error) {
+    Logger.error(`fetchCommitteeById failed: ${(error as Error).message}`);
+    return { success: false, error: "Failed to fetch committee." };
+  }
+}

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -16,3 +16,26 @@ export interface InternshipApplication {
 export type FetchApplicationByIdResult =
   | { success: true; data: InternshipApplication }
   | { success: false; error: string };
+
+export interface InternshipCommitteeQuestion {
+  questionKey: string;
+  questionText: string;
+  questionType: "short_text" | "long_text" | "multiple_choice";
+  required: boolean;
+  order: number;
+  choices: string[];
+}
+
+export interface InternshipCommittee {
+  id: string;
+  name: string;
+  displayName: string;
+  description?: string;
+  subcommittees: string[];
+  isActive: boolean;
+  internLimit?: number;
+  applicationDeadline?: string;
+  customQuestions: InternshipCommitteeQuestion[];
+}
+
+export type FetchCommitteeByIdResult = { success: true; data: InternshipCommittee } | { success: false; error: string };

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -3,3 +3,16 @@ export interface InternshipQuestionResponse {
   question: string;
   answer: string;
 }
+
+export interface InternshipApplication {
+  uuid: string;
+  applicant: string;
+  status: string;
+  responses: InternshipQuestionResponse[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type FetchApplicationByIdResult =
+  | { success: true; data: InternshipApplication }
+  | { success: false; error: string };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^20",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.58.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.10",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.58.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["node"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Description

Implements the fetchApplicationById server action. Action retrieves a single internship application by ID with authentication validation, officer-only access control, backend API communication, and standardized error reporting.

## Related Issue

Resolves #276 

## Steps to view & test changes:

Call fetchApplicationById with a valid application ID from a server component or another action while authenticated as an officer. Verify it returns { success: true, data: application } on success and { success: false, error: "Failed to fetch application." } on failure etc.

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
