### PR TITLE
Feat/fetch all applications

### DIFF
--- a/app/actions/internship/fetchAllApplications.ts
+++ b/app/actions/internship/fetchAllApplications.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenAdmin, isTokenOfficer } from "@/lib/token";
+import type {
+  InternshipApplication,
+  InternshipApplicationsResult,
+} from "@/lib/types/Internship";
+
+const APPLICATIONS_PAGE_LIMIT = 100;
+
+export default async function fetchAllApplications(): Promise<InternshipApplicationsResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) {
+      return { success: false, error: "Not authenticated" };
+    }
+
+    if (!isTokenAdmin(token) && !isTokenOfficer(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const url = `${Config.API_URL}${Config.routes.internship.applications}?limit=${APPLICATIONS_PAGE_LIMIT}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || data?.success === false) {
+      const validationMessage = Array.isArray(data?.errors) ? data.errors[0]?.msg : undefined;
+      const message =
+        validationMessage ?? data?.message ?? data?.error ?? "Failed to fetch applications";
+      Logger.error(`fetchAllApplications failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    const applications: InternshipApplication[] = data.data ?? [];
+    return { success: true, data: applications };
+  } catch (err) {
+    Logger.error(`fetchAllApplications failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch applications" };
+  }
+}

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -17,7 +17,7 @@ function tokenGetClaims(token: string) {
   return JSON.parse(decodedPayload);
 }
 
-export function isAuthenticated(token: string | undefined): boolean {
+export function isAuthenticated(token: string | undefined): token is string {
   return !!token;
 }
 

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -3,3 +3,35 @@ export interface InternshipQuestionResponse {
   question: string;
   answer: string;
 }
+
+export interface InternshipApplication {
+  _id: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  university: string;
+  major: string;
+  graduationYear: number;
+  resumeUrl?: string;
+  coverLetter?: string;
+  firstChoiceCommittee: string;
+  secondChoiceCommittee?: string;
+  thirdChoiceCommittee?: string;
+  firstChoiceResponses: InternshipQuestionResponse[];
+  secondChoiceResponses: InternshipQuestionResponse[];
+  thirdChoiceResponses: InternshipQuestionResponse[];
+  firstChoiceStatus: string;
+  secondChoiceStatus: string;
+  thirdChoiceStatus: string;
+  applicationCycle: string;
+  submittedAt: string;
+  lastModifiedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type InternshipApplicationsResult =
+  | { success: true; data: InternshipApplication[] }
+  | { success: false; error: string };


### PR DESCRIPTION
## Description

Implements the fetchAllApplications server action under app/actions/internship/. The action validates the user's cookie-based auth token, only allows access to admins and officers, calls GET /api/v1/internship/applications with limit=100 and returns a typed InternshipApplicationsResult (either a success with the applications array or a failure with an error message). Also adds the InternshipApplication interface (matches the mongoose schema) and the InternshipApplicationsResult type to lib/types/Internship.ts.

## Related Issue

Resolves #275

## Steps to view & test changes:

- Import and call fetchAllApplications() from a server component or another server action with a valid admin/officer session cookie
- Verify it returns { success: true, data: InternshipApplication[] } for an admin or officer
- Verify it returns { success: false, error: "Not authenticated" } when no token cookie is present
- Verify it returns { success: false, error: "Not authorized" } when the user is signed in but doesn't have admin/officer access

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)

N/A