### PR TITLE
feat: create committee

### DIFF
--- a/app/actions/internship/createCommittee.ts
+++ b/app/actions/internship/createCommittee.ts
@@ -1,0 +1,73 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type {
+  CreateInternshipCommitteePayload,
+  CreateInternshipCommitteeResult,
+  InternshipCommittee,
+} from "@/lib/types/Internship";
+
+export default async function createCommittee(
+  committee: CreateInternshipCommitteePayload,
+): Promise<CreateInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(Config.API_URL + Config.routes.internship.committees, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(committee),
+    });
+
+    const text = await response.text();
+    let data: any = null;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      if (!response.ok) {
+        const msg = `Request failed (${response.status})`;
+        Logger.error(`createCommittee failed: ${msg}`);
+        return { success: false, error: msg };
+      }
+    }
+
+    if (!response.ok) {
+      const msg =
+        data?.message ??
+        (typeof data?.error === "string" ? data.error : data?.error?.message) ??
+        `Request failed (${response.status})`;
+      Logger.error(`createCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    if (data?.error) {
+      const msg = typeof data.error === "string" ? data.error : data.error.message;
+      Logger.error(`createCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const created: InternshipCommittee | undefined = data?.committee;
+    if (!created) {
+      Logger.error("createCommittee failed: missing committee in response");
+      return { success: false, error: "Failed to create committee." };
+    }
+
+    return { success: true, data: created };
+  } catch (err) {
+    Logger.error(`createCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to create committee." };
+  }
+}

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -39,3 +39,27 @@ export interface InternshipCommittee {
 }
 
 export type FetchCommitteeByIdResult = { success: true; data: InternshipCommittee } | { success: false; error: string };
+
+export interface InternshipCustomQuestion {
+  questionKey: string;
+  questionText: string;
+  questionType: "short_text" | "long_text" | "multiple_choice";
+  required?: boolean;
+  order?: number;
+  choices?: string[];
+}
+
+export type CreateInternshipCommitteePayload = {
+  name: string;
+  displayName: string;
+  description?: string;
+  subcommittees?: string[];
+  isActive?: boolean;
+  internLimit?: number;
+  applicationDeadline?: string | Date;
+  customQuestions?: InternshipCustomQuestion[];
+};
+
+export type CreateInternshipCommitteeResult =
+  | { success: true; data: InternshipCommittee }
+  | { success: false; error: string };


### PR DESCRIPTION
## Description

Implemented createCommittee server action for internship with ability to create new internship committee. Admin authentication is required to perform this action, and error reporting is enabled. 

## Related Issue

Resolves #278 

## Steps to view & test changes:

- Create a test component to call the server action, and verify that correct output is produced when user is in admin mode vs. error message when not as admin
<details>
<summary> Example code I used </summary>

```ts
// app/test-committee/page.tsx
"use client";

import { useState } from "react";
import createCommittee from "@/app/actions/internship/createCommittee";

export default function TestCommitteePage() {
  const [result, setResult] = useState<any>(null);
  const [loading, setLoading] = useState(false);

  const handleCreate = async () => {
    setLoading(true);
    try {
      const committeeData = {
        name: "test-committee",
        displayName: "Test Committee",
        description: "A test committee for development"
      };
      
      const response = await createCommittee(committeeData);
      setResult(response);
    } catch (error) {
      setResult({ success: false, error: (error as Error).message });
    }
    setLoading(false);
  };

  return (
    <div className="p-8">
      <h1>Test createCommittee Action</h1>
      <button 
        onClick={handleCreate} 
        disabled={loading}
        className="px-4 py-2 bg-blue-500 text-white rounded"
      >
        {loading ? "Creating..." : "Create Test Committee"}
      </button>
      
      {result && (
        <pre className="mt-4 p-4 bg-gray-100 rounded">
          {JSON.stringify(result, null, 2)}
        </pre>
      )}
    </div>
  );
}
```
</details>

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)

(Using the test create committee code)

As admin:
<img width="701" height="562" alt="image" src="https://github.com/user-attachments/assets/35fc2a88-1f7e-4f46-a993-a7d6ea256fe3" />

As regular user:
<img width="374" height="277" alt="image" src="https://github.com/user-attachments/assets/2bcebff2-03fa-4677-8a98-dbdd04ef5b4e" />
