### PR TITLE
fix: scroll to top on career hub page (#289)

### DIFF
--- a/app/profile/careerLanding.scss
+++ b/app/profile/careerLanding.scss
@@ -1,7 +1,7 @@
 .career-landing {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 80px 20px;
 
   .career-landing-header {
     text-align: center;
@@ -351,6 +351,7 @@
 
 @media (max-width: 1024px) {
   .career-landing {
+    padding-top: 80px;
     .career-landing-content {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## Description

Added padding so user can scroll to top of Career Hub page 

## Related Issue

Resolves #289 

## Steps to view & test changes:

- checkout fix/career-hub-nav-bar
- test on local host. go to Career Hub, should be able to scroll to top of page

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
