### PR TITLE
feat: Internship Portal IP Entry Point & Role Routing Phase 1

### DIFF
--- a/app/actions/internship/fetchOwnApplication.ts
+++ b/app/actions/internship/fetchOwnApplication.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated } from "@/lib/token";
+import type { InternshipApplication } from "@/lib/types/Internship";
+
+type FetchOwnApplicationResult =
+  | { success: true; data: InternshipApplication }
+  | { success: false; error: string; notFound?: boolean };
+
+export default async function fetchOwnApplication(): Promise<FetchOwnApplicationResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(Config.API_URL + Config.routes.internship.ownApplication, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (response.status === 404) {
+      return { success: false, error: "No application found", notFound: true };
+    }
+
+    const data = await response.json();
+    if (!data.success) return { success: false, error: data.message ?? "Failed to fetch application." };
+
+    return { success: true, data: data.data as InternshipApplication };
+  } catch (err) {
+    Logger.error(`fetchOwnApplication failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application." };
+  }
+}

--- a/app/internship/admin/page.jsx
+++ b/app/internship/admin/page.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import AdminDashboard from "@/components/Internship/AdminDashboard";
+
+export default function AdminPage() {
+  return (
+    <ProtectedRoute requiredRole="admin">
+      <AdminDashboard />
+    </ProtectedRoute>
+  );
+}

--- a/app/internship/apply/page.jsx
+++ b/app/internship/apply/page.jsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useRouter } from "next/navigation";
+import { isAdminAtom, isOfficerAtom, myApplicationAtom } from "@/lib/atoms";
+import fetchOwnApplication from "@/app/actions/internship/fetchOwnApplication";
+import OfficerIneligibilityMessage from "@/components/Internship/OfficerIneligibilityMessage";
+
+export default function ApplyPage() {
+  const isAdmin = useAtomValue(isAdminAtom);
+  const isOfficer = useAtomValue(isOfficerAtom);
+  const myApplication = useAtomValue(myApplicationAtom);
+  const setMyApplication = useSetAtom(myApplicationAtom);
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setMounted(true));
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    if (isAdmin || isOfficer) return;
+
+    fetchOwnApplication().then(result => {
+      if (result.success) {
+        setMyApplication(result.data);
+      }
+    });
+  }, [mounted, isAdmin, isOfficer, setMyApplication]);
+
+  useEffect(() => {
+    if (!mounted) return;
+    if (myApplication?.submissionStatus === "submitted") {
+      router.replace("/internship");
+    }
+  }, [mounted, myApplication, router]);
+
+  if (!mounted) return null;
+
+  if (isAdmin || isOfficer) return <OfficerIneligibilityMessage />;
+
+  if (myApplication?.submissionStatus === "submitted") return null;
+
+  return (
+    <div>
+      <h1>Apply for Internship</h1>
+      <p>Application wizard coming in Phase 2.</p>
+    </div>
+  );
+}

--- a/app/internship/layout.jsx
+++ b/app/internship/layout.jsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
+import Topbar from "@/components/Topbar";
+import CycleStatusBanner from "@/components/Internship/CycleStatusBanner";
+import logoutUser from "@/app/actions/auth/logoutUser";
+import { authUserProfileAtom, isAdminAtom, isOfficerAtom, adminViewAtom, officerViewAtom } from "@/lib/atoms";
+
+export default function InternshipLayout({ children }) {
+  const userProfile = useAtomValue(authUserProfileAtom);
+  const isAdmin = useAtomValue(isAdminAtom);
+  const isOfficer = useAtomValue(isOfficerAtom);
+  const [adminView, setAdminView] = useAtom(adminViewAtom);
+  const [officerView, setOfficerView] = useAtom(officerViewAtom);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setMounted(true));
+  }, []);
+
+  const handleLogout = async () => {
+    await logoutUser();
+  };
+
+  if (!mounted) return null;
+
+  return (
+    <>
+      <Topbar
+        isAdmin={adminView}
+        picture={userProfile?.picture}
+        onLogout={handleLogout}
+        isRealAdmin={isAdmin}
+        adminView={adminView}
+        onToggleAdminView={() => setAdminView(v => !v)}
+        isOfficer={isOfficer}
+        officerView={officerView}
+        onToggleOfficerView={() => setOfficerView(v => !v)}
+      />
+      <CycleStatusBanner />
+      {children}
+    </>
+  );
+}

--- a/app/internship/officer/page.jsx
+++ b/app/internship/officer/page.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import OfficerDashboard from "@/components/Internship/OfficerDashboard";
+
+export default function OfficerPage() {
+  return (
+    <ProtectedRoute requiredRole="officer">
+      <OfficerDashboard />
+    </ProtectedRoute>
+  );
+}

--- a/app/internship/page.jsx
+++ b/app/internship/page.jsx
@@ -1,5 +1,24 @@
-export default async function InternshipPage() {
-  return (
-    <h1>Internship Page</h1>
-  );
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAtomValue } from "jotai";
+import { isAdminAtom, isOfficerAtom } from "@/lib/atoms";
+import AdminDashboard from "@/components/Internship/AdminDashboard";
+import OfficerDashboard from "@/components/Internship/OfficerDashboard";
+import MemberDashboard from "@/components/Internship/MemberDashboard";
+
+export default function InternshipPage() {
+  const isAdmin = useAtomValue(isAdminAtom);
+  const isOfficer = useAtomValue(isOfficerAtom);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setMounted(true));
+  }, []);
+
+  if (!mounted) return null;
+
+  if (isAdmin) return <AdminDashboard />;
+  if (isOfficer) return <OfficerDashboard />;
+  return <MemberDashboard />;
 }

--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function AdminDashboard() {
+  return (
+    <div>
+      <h2>Admin Dashboard</h2>
+    </div>
+  );
+}

--- a/components/Internship/CycleStatusBanner.jsx
+++ b/components/Internship/CycleStatusBanner.jsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function CycleStatusBanner() {
+  return null;
+}

--- a/components/Internship/MemberDashboard.jsx
+++ b/components/Internship/MemberDashboard.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function MemberDashboard() {
+  return (
+    <div>
+      <h2>Member Dashboard</h2>
+    </div>
+  );
+}

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function OfficerDashboard() {
+  return (
+    <div>
+      <h2>Officer Dashboard</h2>
+    </div>
+  );
+}

--- a/components/Internship/OfficerIneligibilityMessage.jsx
+++ b/components/Internship/OfficerIneligibilityMessage.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+import "./style.scss";
+
+export default function OfficerIneligibilityMessage() {
+  return (
+    <div className="officer-ineligibility-message">
+      <h2>Application Unavailable</h2>
+      <p>
+        Officers and Admins are not eligible to apply for internship positions.
+      </p>
+      <p>If you need to review applications, visit your dashboard.</p>
+    </div>
+  );
+}

--- a/components/Internship/ProtectedRoute.jsx
+++ b/components/Internship/ProtectedRoute.jsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAtomValue } from "jotai";
+import { useRouter } from "next/navigation";
+import { isAdminAtom, isOfficerAtom } from "@/lib/atoms";
+
+export default function ProtectedRoute({ children, requiredRole }) {
+  const isAdmin = useAtomValue(isAdminAtom);
+  const isOfficer = useAtomValue(isOfficerAtom);
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setMounted(true));
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    if (requiredRole === "officer" && !isAdmin && !isOfficer) {
+      router.replace("/internship");
+      return;
+    }
+
+    if (requiredRole === "admin" && !isAdmin) {
+      router.replace(isOfficer ? "/internship/officer" : "/internship");
+    }
+  }, [mounted, isAdmin, isOfficer, requiredRole, router]);
+
+  if (!mounted) return null;
+  if (requiredRole === "officer" && !isAdmin && !isOfficer) return null;
+  if (requiredRole === "admin" && !isAdmin) return null;
+
+  return children;
+}

--- a/components/Internship/style.scss
+++ b/components/Internship/style.scss
@@ -1,0 +1,8 @@
+@use "@/styles/vars";
+
+.officer-ineligibility-message {
+  padding: 2rem;
+  max-width: 600px;
+  margin: 4rem auto;
+  text-align: center;
+}

--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -3,9 +3,11 @@
 import { atom } from "jotai";
 
 import type { UserExtendedProfile, UserPublicProfile } from "@/lib/types/User";
+import type { InternshipApplication } from "@/lib/types/Internship";
 
 export const authUserProfileAtom = atom<UserPublicProfile | UserExtendedProfile | null>(null);
 export const isAdminAtom = atom<boolean>(false);
 export const isOfficerAtom = atom<boolean>(false);
 export const adminViewAtom = atom<boolean>(false);
 export const officerViewAtom = atom<boolean>(false);
+export const myApplicationAtom = atom<InternshipApplication | null>(null);

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -8,6 +8,7 @@ export interface InternshipApplication {
   uuid: string;
   applicant: string;
   status: string;
+  submissionStatus: "draft" | "submitted";
   responses: InternshipQuestionResponse[];
   createdAt: string;
   updatedAt: string;

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -5,7 +5,6 @@ export interface InternshipQuestionResponse {
 }
 
 export interface InternshipApplication {
-<<<<<<< HEAD
   _id: string;
   userId: string;
   firstName: string;


### PR DESCRIPTION
## Description

Phase 1: Security & Routing Infrastructure — focus on the "invisible" logic that protects the application.

- **ProtectedRoute Wrapper:** Implements a wrapper component that reads the `isAdmin` and `isOfficer` Jotai atoms to permit or block access to sub-routes.
- **Validation Rigidity:**
  - `/internship/officer`: Redirects to `/internship` if the user is not an Officer or Admin.
  - `/internship/admin`: Redirects to `/internship/officer` if they are an Officer, otherwise to `/internship`.
- **Logic Guards for `/internship/apply`:**
  - **Submission Guard:** If `myApplicationAtom` shows a submitted status, redirect to the dashboard.
  - **Role Guard:** If the user is an Officer or Admin, render the `OfficerIneligibilityMessage` component instead of the wizard (do not redirect; explain the policy).

## Related Issue

Resolves #309  

## Steps to view & test changes:

- Visit `/internship/officer` as a member → should redirect to `/internship`
- Visit `/internship/officer` as an officer or admin → should render Officer Dashboard
- Visit `/internship/admin` as a member → should redirect to `/internship`
- Visit `/internship/admin` as an officer → should redirect to `/internship/officer`
- Visit `/internship/admin` as an admin → should render Admin Dashboard
- Visit `/internship/apply` as an officer or admin → should render the ineligibility message (no redirect)
- Visit `/internship/apply` as a member with a submitted application → should redirect to `/internship`
- Visit `/internship/apply` as a member with no application → should render the wizard placeholder

## How Has This Been Tested?

- [x ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)