### PR TITLE
feat: Admin Committee Management Phase 1

### DIFF
--- a/app/actions/internship/bulkUpdateCommitteeStatus.ts
+++ b/app/actions/internship/bulkUpdateCommitteeStatus.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenAdmin } from "@/lib/token";
+import type {
+  BulkUpdateCommitteeStatusPayload,
+  BulkUpdateCommitteeStatusResult,
+} from "@/lib/types/Internship";
+
+export default async function bulkUpdateCommitteeStatus(
+  payload: BulkUpdateCommitteeStatusPayload,
+): Promise<BulkUpdateCommitteeStatusResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) {
+      return { success: false, error: "Not authenticated" };
+    }
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const body: { action: "open" | "close"; committeeIds?: string[] } = { action: payload.action };
+    if (payload.committeeIds && payload.committeeIds.length > 0) {
+      body.committeeIds = payload.committeeIds;
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committeesBulkStatus}`,
+      {
+        method: "PATCH",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || !data?.success) {
+      const message =
+        data?.error?.message ?? data?.message ?? `Request failed (${response.status})`;
+      Logger.error(`bulkUpdateCommitteeStatus failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    return { success: true, modified: typeof data.modified === "number" ? data.modified : 0 };
+  } catch (err) {
+    Logger.error(`bulkUpdateCommitteeStatus failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update committee status" };
+  }
+}

--- a/app/actions/internship/fetchCommittees.ts
+++ b/app/actions/internship/fetchCommittees.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenAdmin } from "@/lib/token";
+import type {
+  FetchCommitteesResult,
+  InternshipCommitteeAdminListItem,
+} from "@/lib/types/Internship";
+
+export default async function fetchCommittees(): Promise<FetchCommitteesResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) {
+      return { success: false, error: "Not authenticated" };
+    }
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.committeesAdmin}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || data?.error) {
+      const message = data?.error?.message ?? data?.message ?? "Failed to fetch committees";
+      Logger.error(`fetchCommittees failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    const raw = Array.isArray(data?.committees) ? data.committees : [];
+    const committees: InternshipCommitteeAdminListItem[] = raw.map((c: any) => ({
+      ...c,
+      id: c.id ?? c._id,
+    }));
+
+    return { success: true, data: committees };
+  } catch (err) {
+    Logger.error(`fetchCommittees failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch committees" };
+  }
+}

--- a/app/internship/admin/committees/[id]/edit/page.jsx
+++ b/app/internship/admin/committees/[id]/edit/page.jsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { use } from "react";
+import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+
+export default function EditCommitteePage({ params }) {
+  const { id } = use(params);
+  return (
+    <ProtectedRoute requiredRole="admin">
+      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+        <h2>Edit Committee</h2>
+        <p>Committee editor coming soon. Editing committee: <code>{id}</code></p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/internship/admin/committees/new/page.jsx
+++ b/app/internship/admin/committees/new/page.jsx
@@ -1,0 +1,14 @@
+"use client";
+
+import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+
+export default function NewCommitteePage() {
+  return (
+    <ProtectedRoute requiredRole="admin">
+      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+        <h2>Create Committee</h2>
+        <p>Committee editor coming soon.</p>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -1,9 +1,75 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
+import CommitteeTable from "@/components/Internship/CommitteeTable";
+import fetchCommittees from "@/app/actions/internship/fetchCommittees";
+import "./AdminDashboard.scss";
+
+const TABS = [
+  { id: "committees", label: "Committees" },
+  { id: "applications", label: "Applications" },
+];
+
 export default function AdminDashboard() {
+  const [activeTab, setActiveTab] = useState("committees");
+  const [committees, setCommittees] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const loadCommittees = useCallback(async () => {
+    setLoading(true);
+    const result = await fetchCommittees();
+    if (result.success) {
+      setCommittees(result.data);
+      setError(null);
+    } else {
+      setError(result.error);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    Promise.resolve().then(loadCommittees);
+  }, [loadCommittees]);
+
   return (
-    <div>
+    <div className="admin-dashboard">
       <h2>Admin Dashboard</h2>
+      <div className="admin-dashboard__tabs" role="tablist">
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={`admin-dashboard__tab${
+              activeTab === tab.id ? " admin-dashboard__tab--active" : ""
+            }`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="admin-dashboard__panel" role="tabpanel">
+        {activeTab === "committees" && (
+          <>
+            {loading && <div className="admin-dashboard__placeholder">Loading committees…</div>}
+            {!loading && error && (
+              <div className="committee-table-wrapper__error">{error}</div>
+            )}
+            {!loading && !error && (
+              <CommitteeTable committees={committees} onMutated={loadCommittees} />
+            )}
+          </>
+        )}
+        {activeTab === "applications" && (
+          <div className="admin-dashboard__placeholder">
+            Application oversight will appear here in Phase 2.
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -1,0 +1,206 @@
+@use "@/styles/vars";
+
+.admin-dashboard {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  &__tabs {
+    display: flex;
+    gap: 0.5rem;
+    border-bottom: 1px solid vars.$gray1;
+    margin-bottom: 1.5rem;
+  }
+
+  &__tab {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0.75rem 1.25rem;
+    font-size: 1rem;
+    font-weight: 500;
+    color: vars.$gray3;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+
+    &:hover {
+      color: vars.$primary-color;
+    }
+
+    &--active {
+      color: vars.$primary-color;
+      border-bottom-color: vars.$primary-color;
+    }
+  }
+
+  &__panel {
+    min-height: 200px;
+  }
+
+  &__placeholder {
+    padding: 2rem;
+    color: vars.$gray3;
+    text-align: center;
+  }
+}
+
+.committee-table-wrapper {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  &__bulk-btn {
+    appearance: none;
+    background: vars.$white;
+    color: vars.$primary-color;
+    border: 1px solid vars.$primary-color;
+    padding: 0.4rem 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    transition: background 0.15s, color 0.15s;
+
+    &:hover:not(:disabled) {
+      background: vars.$primary-color;
+      color: vars.$white;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__error {
+    background: rgba(247, 78, 78, 0.1);
+    color: vars.$dark-red;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+  }
+
+  &__empty {
+    padding: 2rem;
+    text-align: center;
+    color: vars.$gray3;
+  }
+}
+
+.committee-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.75rem 0.5rem;
+    border-bottom: 1px solid vars.$gray1;
+  }
+
+  th {
+    font-weight: 600;
+    color: vars.$gray3;
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  tr:hover td {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  &__checkbox-col {
+    width: 32px;
+  }
+
+  &__status {
+    display: inline-block;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+
+    &--active {
+      background: rgba(52, 220, 106, 0.15);
+      color: vars.$dark-green;
+    }
+
+    &--inactive {
+      background: rgba(0, 0, 0, 0.08);
+      color: vars.$gray3;
+    }
+  }
+
+  &__edit-link {
+    color: vars.$secondary-color;
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: vars.$primary-color;
+  color: vars.$white;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+
+  &__count {
+    font-weight: 500;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-left: auto;
+  }
+
+  &__btn {
+    appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: transparent;
+    color: vars.$white;
+    padding: 0.4rem 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.15);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__clear {
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: vars.$white;
+    cursor: pointer;
+    text-decoration: underline;
+    font-size: 0.85rem;
+  }
+}

--- a/components/Internship/BulkActionBar.jsx
+++ b/components/Internship/BulkActionBar.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+export default function BulkActionBar({ selectedCount, onOpen, onClose, onClear, disabled }) {
+  return (
+    <div className="bulk-action-bar">
+      <span className="bulk-action-bar__count">
+        {selectedCount} selected
+      </span>
+      <button type="button" className="bulk-action-bar__clear" onClick={onClear} disabled={disabled}>
+        Clear
+      </button>
+      <div className="bulk-action-bar__actions">
+        <button type="button" className="bulk-action-bar__btn" onClick={onOpen} disabled={disabled}>
+          Open Selected
+        </button>
+        <button type="button" className="bulk-action-bar__btn" onClick={onClose} disabled={disabled}>
+          Close Selected
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/Internship/CommitteeTable.jsx
+++ b/components/Internship/CommitteeTable.jsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import BulkActionBar from "@/components/Internship/BulkActionBar";
+import bulkUpdateCommitteeStatus from "@/app/actions/internship/bulkUpdateCommitteeStatus";
+
+function formatDeadline(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+export default function CommitteeTable({ committees, onMutated }) {
+  const [selected, setSelected] = useState(() => new Set());
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState(null);
+
+  const allIds = useMemo(() => committees.map(c => c.id), [committees]);
+  const allChecked = allIds.length > 0 && selected.size === allIds.length;
+  const someChecked = selected.size > 0 && !allChecked;
+
+  function toggle(id) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    setSelected(allChecked ? new Set() : new Set(allIds));
+  }
+
+  function clearSelection() {
+    setSelected(new Set());
+  }
+
+  async function runBulk(action, committeeIds) {
+    setPending(true);
+    setError(null);
+    const result = await bulkUpdateCommitteeStatus({ action, committeeIds });
+    setPending(false);
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    clearSelection();
+    onMutated?.();
+  }
+
+  return (
+    <div className="committee-table-wrapper">
+      <div className="committee-table-wrapper__header">
+        <h3>Committees</h3>
+        <div className="committee-table-wrapper__actions">
+          <button
+            type="button"
+            className="committee-table-wrapper__bulk-btn"
+            onClick={() => runBulk("open")}
+            disabled={pending}
+          >
+            Open All
+          </button>
+          <button
+            type="button"
+            className="committee-table-wrapper__bulk-btn"
+            onClick={() => runBulk("close")}
+            disabled={pending}
+          >
+            Close All
+          </button>
+          <Link href="/internship/admin/committees/new" className="committee-table__edit-link">
+            + Create Committee
+          </Link>
+        </div>
+      </div>
+
+      {error && <div className="committee-table-wrapper__error">{error}</div>}
+
+      {selected.size > 0 && (
+        <BulkActionBar
+          selectedCount={selected.size}
+          disabled={pending}
+          onOpen={() => runBulk("open", Array.from(selected))}
+          onClose={() => runBulk("close", Array.from(selected))}
+          onClear={clearSelection}
+        />
+      )}
+
+      {committees.length === 0 ? (
+        <div className="committee-table-wrapper__empty">No committees yet.</div>
+      ) : (
+        <table className="committee-table">
+          <thead>
+            <tr>
+              <th className="committee-table__checkbox-col">
+                <input
+                  type="checkbox"
+                  checked={allChecked}
+                  ref={el => {
+                    if (el) el.indeterminate = someChecked;
+                  }}
+                  onChange={toggleAll}
+                  aria-label="Select all committees"
+                />
+              </th>
+              <th>Display Name</th>
+              <th>Internal Name</th>
+              <th>Status</th>
+              <th>Deadline</th>
+              <th>Intern Limit</th>
+              <th>Applications</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {committees.map(c => (
+              <tr key={c.id}>
+                <td>
+                  <input
+                    type="checkbox"
+                    checked={selected.has(c.id)}
+                    onChange={() => toggle(c.id)}
+                    aria-label={`Select ${c.displayName}`}
+                  />
+                </td>
+                <td>{c.displayName}</td>
+                <td>{c.name}</td>
+                <td>
+                  <span
+                    className={`committee-table__status committee-table__status--${
+                      c.isActive ? "active" : "inactive"
+                    }`}
+                  >
+                    {c.isActive ? "Active" : "Inactive"}
+                  </span>
+                </td>
+                <td>{formatDeadline(c.applicationDeadline)}</td>
+                <td>{c.internLimit ?? "—"}</td>
+                <td>{c.applicationCount ?? 0}</td>
+                <td>
+                  <Link
+                    href={`/internship/admin/committees/${c.id}/edit`}
+                    className="committee-table__edit-link"
+                  >
+                    Edit
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -38,6 +38,8 @@ const config = {
       applications: "/api/v1/internship/applications",
       ownApplication: "/api/v1/internship/applications/me",
       committees: "/api/v1/internship/committees",
+      committeesAdmin: "/api/v1/internship/committees/admin",
+      committeesBulkStatus: "/api/v1/internship/committees/bulk-status",
     },
     leaderboard: "/api/v1/leaderboard",
     admin: {

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -63,6 +63,25 @@ export interface InternshipCommittee {
 
 export type FetchCommitteeByIdResult = { success: true; data: InternshipCommittee } | { success: false; error: string };
 
+export interface InternshipCommitteeAdminListItem extends InternshipCommittee {
+  applicationCount: number;
+}
+
+export type FetchCommitteesResult =
+  | { success: true; data: InternshipCommitteeAdminListItem[] }
+  | { success: false; error: string };
+
+export type BulkCommitteeStatusAction = "open" | "close";
+
+export type BulkUpdateCommitteeStatusPayload = {
+  action: BulkCommitteeStatusAction;
+  committeeIds?: string[];
+};
+
+export type BulkUpdateCommitteeStatusResult =
+  | { success: true; modified: number }
+  | { success: false; error: string };
+
 export interface InternshipCustomQuestion {
   questionKey: string;
   questionText: string;


### PR DESCRIPTION
## Description

- Add tabbed admin dashboard at `/internship/admin` toggling between Committees and Applications (Applications tab is a Phase 2 placeholder)
- Build the Committees table (Display Name, Internal Name, Status, Deadline, Intern Limit, Application Count) with row selection, Edit links, and a Create Committee entry point
- Implement bulk lifecycle controls: per-selection "Open Selected" / "Close Selected" bar plus top-level "Open All" / "Close All" buttons that call `bulkUpdateCommitteeStatus` (omitting `committeeIds` to target every committee)
- Add server actions `fetchCommittees` and `bulkUpdateCommitteeStatus`, both gated on `isTokenAdmin`
- Stub `/internship/admin/committees/new` and `/internship/admin/committees/[id]/edit` routes behind `ProtectedRoute` so the table's navigation links resolve (full CommitteeEditor is out of scope for this phase)

## Related Issue

Resolves #318 

## Steps to view & test changes:

- Log in as an admin and visit `/internship/admin` — Committees tab is selected by default
- After creating a committee via the API, the row appears with all six columns populated

## How Has This Been Tested?

- [X] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="2553" height="1373" alt="Screenshot 2026-05-10 at 8 37 17 PM" src="https://github.com/user-attachments/assets/cb710e7c-65ef-4321-94fa-0a3bf7bd638f" />
