### PR TITLE
feat: IP Member Dashboard & Committee Cards Phase #1

### DIFF
--- a/app/actions/internship/fetchAllCommittees.ts
+++ b/app/actions/internship/fetchAllCommittees.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated } from "@/lib/token";
+import type { InternshipCommittee } from "@/lib/types/Internship";
+
+type FetchAllCommitteesResult =
+  | { success: true; data: InternshipCommittee[] }
+  | { success: false; error: string };
+
+export default async function fetchAllCommittees(): Promise<FetchAllCommitteesResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.committees}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json();
+    if (!data || data.error) return { success: false, error: data?.error?.message ?? "Failed to fetch committees." };
+
+    const committees: InternshipCommittee[] = data.committees ?? [];
+    return { success: true, data: committees };
+  } catch (err) {
+    Logger.error(`fetchAllCommittees failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch committees." };
+  }
+}

--- a/app/test-committee/page.tsx
+++ b/app/test-committee/page.tsx
@@ -1,0 +1,46 @@
+// app/test-committee/page.tsx
+"use client";
+ 
+import { useState } from "react";
+import createCommittee from "@/app/actions/internship/createCommittee";
+ 
+export default function TestCommitteePage() {
+  const [result, setResult] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+ 
+  const handleCreate = async () => {
+    setLoading(true);
+    try {
+      const committeeData = {
+        name: "test_committee",
+        displayName: "Test Committee", 
+        description: "A test committee for development"
+      };
+      
+      const response = await createCommittee(committeeData);
+      setResult(response);
+    } catch (error) {
+      setResult({ success: false, error: (error as Error).message });
+    }
+    setLoading(false);
+  };
+ 
+  return (
+    <div className="p-8">
+      <h1>Test createCommittee Action</h1>
+      <button 
+        onClick={handleCreate} 
+        disabled={loading}
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        {loading ? "Creating..." : "Create Test Committee"}
+      </button>
+      
+      {result && (
+        <pre className="mt-4 p-4 bg-gray-100 rounded">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/components/Internship/ApplicationStatusCard.jsx
+++ b/components/Internship/ApplicationStatusCard.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useAtomValue } from "jotai";
+import { myApplicationAtom } from "@/lib/atoms";
+import "./style.scss";
+
+export default function ApplicationStatusCard() {
+  const myApplication = useAtomValue(myApplicationAtom);
+
+  return (
+    <div className="application-status-card">
+      <h3 className="application-status-card__title">My Application</h3>
+      <div className="application-status-card__content">
+        {myApplication ? (
+          <p>Application exists (Phase 2 implementation)</p>
+        ) : (
+          <p>No application data loaded</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/Internship/CommitteeCard.jsx
+++ b/components/Internship/CommitteeCard.jsx
@@ -1,0 +1,14 @@
+"use client";
+
+import "./style.scss";
+
+export default function CommitteeCard({ committee }) {
+  return (
+    <div className="committee-card">
+      <h4 className="committee-card__name">{committee.displayName || committee.name}</h4>
+      {committee.description && (
+        <p className="committee-card__description">{committee.description}</p>
+      )}
+    </div>
+  );
+}

--- a/components/Internship/MemberDashboard.jsx
+++ b/components/Internship/MemberDashboard.jsx
@@ -1,11 +1,89 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useSetAtom, useAtomValue } from "jotai";
+import { myApplicationAtom, activeCommitteesAtom } from "@/lib/atoms";
+import fetchOwnApplication from "@/app/actions/internship/fetchOwnApplication";
+import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import ApplicationStatusCard from "./ApplicationStatusCard";
+import CommitteeCard from "./CommitteeCard";
 import "./style.scss";
 
 export default function MemberDashboard() {
+  const setMyApplication = useSetAtom(myApplicationAtom);
+  const setActiveCommittees = useSetAtom(activeCommitteesAtom);
+  const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const [mounted, setMounted] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setMounted(true));
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const loadData = async () => {
+      setIsLoading(true);
+
+      const [applicationResult, committeesResult] = await Promise.all([
+        fetchOwnApplication(),
+        fetchAllCommittees(),
+      ]);
+
+      if (applicationResult.success) {
+        setMyApplication(applicationResult.data);
+      } else if (applicationResult.notFound) {
+        setMyApplication(null);
+      }
+
+      if (committeesResult.success) {
+        const active = committeesResult.data.filter((c) => c.isActive);
+        setActiveCommittees(active);
+      } else {
+        setActiveCommittees([]);
+      }
+
+      setIsLoading(false);
+    };
+
+    loadData();
+  }, [mounted, setMyApplication, setActiveCommittees]);
+
+  if (!mounted) return null;
+
+  const committees = activeCommittees ?? [];
+  const hasActiveCommittees = committees.length > 0;
+
   return (
     <div className="member-dashboard">
-      <h2>Member Dashboard</h2>
+      <div className="member-dashboard__container">
+        <div className="member-dashboard__left">
+          <ApplicationStatusCard />
+        </div>
+
+        <div className="member-dashboard__right">
+          <div className="member-dashboard__committee-card">
+            <h3 className="member-dashboard__committee-card-title">Available Committees</h3>
+            
+            {isLoading ? (
+              <div className="member-dashboard__loading">Loading committees...</div>
+            ) : hasActiveCommittees ? (
+              <div className="member-dashboard__committee-grid">
+                {committees.map((committee) => (
+                  <CommitteeCard key={committee.id} committee={committee} />
+                ))}
+              </div>
+            ) : (
+              <div className="member-dashboard__empty-state">
+                <p className="member-dashboard__empty-message">
+                  Internship recruitment is not currently open. Check back later!
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/Internship/style.scss
+++ b/components/Internship/style.scss
@@ -57,9 +57,123 @@
 }
 
 .admin-dashboard,
-.officer-dashboard,
-.member-dashboard {
+.officer-dashboard {
   padding: 2rem;
   max-width: 1100px;
   margin: 2rem auto;
+}
+.member-dashboard {
+  padding: 2rem;
+  margin-top: 61px;
+  height: calc(100vh - 61px);
+  overflow-y: auto;
+
+  &__container {
+    display: flex;
+    flex-direction: row;
+    gap: 1.5rem;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  &__left {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__right {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__right-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: vars.$primaryblack;
+  }
+
+  &__committee-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    padding-right: 0.5rem;
+  }
+
+  &__loading {
+    color: vars.$secondaryblack;
+    font-style: italic;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  &__empty-state {
+    padding: 3rem 2rem;
+    text-align: center;
+    background: vars.$tertiaryblue;
+    border-radius: 8px;
+  }
+
+  &__empty-message {
+    color: vars.$secondaryblack;
+    font-size: 1rem;
+    margin: 0;
+  }
+}
+
+.application-status-card {
+  background: vars.$white;
+  border: 1px solid vars.$gray1;
+  border-radius: 8px;
+  padding: 1.5rem;
+
+  &__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 1rem 0;
+    color: vars.$primaryblack;
+  }
+
+  &__content {
+    color: vars.$secondaryblack;
+  }
+}
+
+.member-dashboard__committee-card {
+  border: 1px solid vars.$gray1;
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.member-dashboard__committee-card-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 1rem 0;
+  color: vars.$primaryblack;
+}
+
+.committee-card {
+  background: vars.$white;
+  border: 1px solid vars.$gray1;
+  border-radius: 8px;
+  padding: 1rem;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  &__name {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem 0;
+    color: vars.$primaryblack;
+  }
+
+  &__description {
+    font-size: 0.875rem;
+    color: vars.$secondaryblack;
+    margin: 0;
+    line-height: 1.4;
+  }
 }

--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -3,7 +3,7 @@
 import { atom } from "jotai";
 
 import type { UserExtendedProfile, UserPublicProfile } from "@/lib/types/User";
-import type { InternshipApplication } from "@/lib/types/Internship";
+import type { InternshipApplication, InternshipCommittee } from "@/lib/types/Internship";
 
 export const authUserProfileAtom = atom<UserPublicProfile | UserExtendedProfile | null>(null);
 export const isAdminAtom = atom<boolean>(false);
@@ -11,3 +11,4 @@ export const isOfficerAtom = atom<boolean>(false);
 export const adminViewAtom = atom<boolean>(false);
 export const officerViewAtom = atom<boolean>(false);
 export const myApplicationAtom = atom<InternshipApplication | null>(null);
+export const activeCommitteesAtom = atom<InternshipCommittee[] | null>(null);


### PR DESCRIPTION
## Description

Phase 1 of #272 

- Added activeCommitteesAtom and myApplicationAtom as global Jotai states in lib/atoms.ts
- Created two-column member dashboard layout. This contains a left column called "My Application" and right column with scrollable grid of Committee Card components
  -  Code exists in components/internship/MemberDashboard.jsx, rendered from app/internship/page.jsx.
Left Column: "My Application" status area (Width: ~50%).
- Createed the "Internship recruitment is not currently open. Check back later!" fallback for the right column when no active committees exist.

## Related Issue

Resolves #312 

## Steps to view & test changes:

- Login as a regular user without admin privileges
- Access http://localhost:8000/internship

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="1878" height="485" alt="image" src="https://github.com/user-attachments/assets/09a17f8e-0671-42d0-b534-3b7dfe67ac3a" />
