### PR TITLE
internship portal phase 3 - global navigation & UI integration

### DIFF
--- a/app/profile/CareerLanding.jsx
+++ b/app/profile/CareerLanding.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Link from 'next/link';
+import React from "react";
+import PropTypes from "prop-types";
+import Link from "next/link";
 import './careerLanding.scss';
 
 export default class CareerLanding extends React.Component {
@@ -20,7 +20,7 @@ export default class CareerLanding extends React.Component {
   }
 
   render() {
-    const { profile } = this.props;
+    const { profile, isInternshipOpen } = this.props;
     const completeness = this.calculateCompleteness();
     const isPublic = profile.isProfilePublic !== undefined ? profile.isProfilePublic : true;
 
@@ -71,16 +71,30 @@ export default class CareerLanding extends React.Component {
               </div>
 
               {/* Committee Applications Card */}
-              <div className="career-card disabled">
-                <div className="career-card-icon">
-                  <i className="fa fa-users" />
+              {isInternshipOpen === false ? (
+                <div className="career-card disabled">
+                  <div className="career-card-icon">
+                    <i className="fa fa-users" />
+                  </div>
+                  <div className="career-card-content">
+                    <h2>Committee Applications</h2>
+                    <p>Apply to join ACM committees and officer positions</p>
+                    <span className="closed-badge">Closed</span>
+                  </div>
                 </div>
-                <div className="career-card-content">
-                  <h2>Committee Applications</h2>
-                  <p>Apply to join ACM committees and officer positions</p>
-                  <span className="coming-soon-badge">Coming Soon</span>
-                </div>
-              </div>
+              ) : (
+                <Link href="/internship" className="career-card">
+                  <div className="career-card-icon">
+                    <i className="fa fa-users" />
+                  </div>
+                  <div className="career-card-content">
+                    <h2>Committee Applications</h2>
+                    <p>Apply to join ACM committees and officer positions</p>
+                    {isInternshipOpen === true && <span className="open-badge">Open</span>}
+                  </div>
+                  <i className="fa fa-chevron-right career-card-arrow" />
+                </Link>
+              )}
 
               {/* Resources Card */}
               <div className="career-card disabled">
@@ -98,9 +112,7 @@ export default class CareerLanding extends React.Component {
             {completeness < 100 && (
               <div className="career-tips">
                 <h3>
-                  <i className="fa fa-lightbulb" />
-                  {' '}
-                  Complete Your Profile
+                  <i className="fa fa-lightbulb" /> Complete Your Profile
                 </h3>
                 <p>A complete profile helps recruiters and committee leads find you:</p>
                 <ul>
@@ -153,7 +165,9 @@ export default class CareerLanding extends React.Component {
                     <h3>Skills</h3>
                     <div className="tags">
                       {profile.skills.map((skill, index) => (
-                        <span key={index} className="tag">{skill}</span>
+                        <span key={index} className="tag">
+                          {skill}
+                        </span>
                       ))}
                     </div>
                   </div>
@@ -164,18 +178,29 @@ export default class CareerLanding extends React.Component {
                     <h3>Career Interests</h3>
                     <div className="tags">
                       {profile.careerInterests.map((interest, index) => (
-                        <span key={index} className="tag">{interest}</span>
+                        <span key={index} className="tag">
+                          {interest}
+                        </span>
                       ))}
                     </div>
                   </div>
                 )}
 
-                {(profile.linkedinUrl || profile.githubUrl || profile.portfolioUrl || profile.personalWebsite || profile.resumeUrl) && (
+                {(profile.linkedinUrl ||
+                  profile.githubUrl ||
+                  profile.portfolioUrl ||
+                  profile.personalWebsite ||
+                  profile.resumeUrl) && (
                   <div className="preview-section">
                     <h3>Links</h3>
                     <div className="preview-links">
                       {profile.linkedinUrl && (
-                        <a href={profile.linkedinUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                        <a
+                          href={profile.linkedinUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="preview-link"
+                        >
                           <i className="fab fa-linkedin" /> LinkedIn
                         </a>
                       )}
@@ -185,12 +210,22 @@ export default class CareerLanding extends React.Component {
                         </a>
                       )}
                       {profile.portfolioUrl && (
-                        <a href={profile.portfolioUrl} target="_blank" rel="noopener noreferrer" className="preview-link">
+                        <a
+                          href={profile.portfolioUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="preview-link"
+                        >
                           <i className="fa fa-folder" /> Portfolio
                         </a>
                       )}
                       {profile.personalWebsite && (
-                        <a href={profile.personalWebsite} target="_blank" rel="noopener noreferrer" className="preview-link">
+                        <a
+                          href={profile.personalWebsite}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="preview-link"
+                        >
                           <i className="fa fa-globe" /> Website
                         </a>
                       )}
@@ -213,8 +248,10 @@ export default class CareerLanding extends React.Component {
 
 CareerLanding.propTypes = {
   profile: PropTypes.object,
+  isInternshipOpen: PropTypes.bool,
 };
 
 CareerLanding.defaultProps = {
   profile: {},
+  isInternshipOpen: null,
 };

--- a/app/profile/career/page.jsx
+++ b/app/profile/career/page.jsx
@@ -1,18 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAtom, useAtomValue } from "jotai";
-import Topbar from "../../../components/Topbar";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import Topbar from "@/components/Topbar";
 import CareerLanding from "../CareerLanding";
-import logoutUser from "../../actions/auth/logoutUser.ts";
-import fetchCareerProfile from "../../actions/user/fetchCareerProfile.ts";
-import { authUserProfileAtom, isAdminAtom, isOfficerAtom, adminViewAtom } from "../../../lib/atoms.ts";
+import logoutUser from "@/app/actions/auth/logoutUser";
+import fetchCareerProfile from "@/app/actions/user/fetchCareerProfile";
+import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import { authUserProfileAtom, isAdminAtom, isOfficerAtom, adminViewAtom, activeCommitteesAtom } from "@/lib/atoms";
 
 export default function CareerPage() {
   const userProfile = useAtomValue(authUserProfileAtom);
   const isAdmin = useAtomValue(isAdminAtom);
   const isOfficer = useAtomValue(isOfficerAtom);
   const [adminView, setAdminView] = useAtom(adminViewAtom);
+  const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const setActiveCommittees = useSetAtom(activeCommitteesAtom);
   const [mounted, setMounted] = useState(false);
   const [careerProfile, setCareerProfile] = useState(userProfile || {});
 
@@ -21,10 +24,7 @@ export default function CareerPage() {
   }, []);
 
   useEffect(() => {
-    if (!userProfile) {
-      return;
-    }
-
+    if (!userProfile) return;
     (async () => {
       const career = await fetchCareerProfile();
       if (career) {
@@ -34,6 +34,17 @@ export default function CareerPage() {
       }
     })();
   }, [userProfile]);
+
+  useEffect(() => {
+    if (activeCommittees !== null) return;
+    fetchAllCommittees().then(result => {
+      if (result.success) {
+        setActiveCommittees(result.data.filter(c => c.isActive));
+      } else {
+        setActiveCommittees([]);
+      }
+    });
+  }, [activeCommittees, setActiveCommittees]);
 
   const handleLogout = async () => {
     await logoutUser();
@@ -51,10 +62,13 @@ export default function CareerPage() {
         adminView={adminView}
         onToggleAdminView={() => setAdminView(v => !v)}
         isOfficer={isOfficer}
-        officerView={adminView}
-        onToggleOfficerView={() => setAdminView(v => !v)}
+        officerView={false}
+        onToggleOfficerView={() => {}}
       />
-      <CareerLanding profile={careerProfile} />
+      <CareerLanding
+        profile={careerProfile}
+        isInternshipOpen={activeCommittees === null ? null : activeCommittees.length > 0}
+      />
     </div>
   );
 }

--- a/app/profile/career/page.jsx
+++ b/app/profile/career/page.jsx
@@ -36,7 +36,6 @@ export default function CareerPage() {
   }, [userProfile]);
 
   useEffect(() => {
-    if (activeCommittees !== null) return;
     fetchAllCommittees().then(result => {
       if (result.success) {
         setActiveCommittees(result.data.filter(c => c.isActive));

--- a/app/profile/careerLanding.scss
+++ b/app/profile/careerLanding.scss
@@ -288,6 +288,28 @@
         font-size: 0.8rem;
         font-weight: 500;
       }
+
+      .open-badge {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 4px 10px;
+        background: #d4f5e2;
+        color: #248a45;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
+
+      .closed-badge {
+        display: inline-block;
+        margin-top: 10px;
+        padding: 4px 10px;
+        background: #e9ecef;
+        color: #666;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: 500;
+      }
     }
 
     .career-card-arrow {

--- a/components/Internship/CycleStatusBanner.jsx
+++ b/components/Internship/CycleStatusBanner.jsx
@@ -1,5 +1,38 @@
 "use client";
 
+import { useEffect } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { activeCommitteesAtom } from "@/lib/atoms";
+import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import "./CycleStatusBanner.scss";
+
 export default function CycleStatusBanner() {
-  return null;
+  const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const setActiveCommittees = useSetAtom(activeCommitteesAtom);
+
+  useEffect(() => {
+    if (activeCommittees !== null) return;
+    fetchAllCommittees().then(result => {
+      if (result.success) {
+        setActiveCommittees(result.data.filter(c => c.isActive));
+      } else {
+        setActiveCommittees([]);
+      }
+    });
+  }, [activeCommittees, setActiveCommittees]);
+
+  if (activeCommittees === null) return null;
+
+  const isOpen = activeCommittees.length > 0;
+
+  return (
+    <div className={`cycle-status-banner cycle-status-banner--${isOpen ? "open" : "closed"}`}>
+      <span className="cycle-status-banner__dot" />
+      <span className="cycle-status-banner__text">
+        {isOpen
+          ? `Internship recruitment is open — ${activeCommittees.length} committee${activeCommittees.length !== 1 ? "s" : ""} accepting applications`
+          : "Internship recruitment is currently closed"}
+      </span>
+    </div>
+  );
 }

--- a/components/Internship/CycleStatusBanner.scss
+++ b/components/Internship/CycleStatusBanner.scss
@@ -1,0 +1,39 @@
+@use "@/styles/vars";
+
+.cycle-status-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 2rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  &--open {
+    background: rgba(vars.$light-green, 0.12);
+    color: vars.$dark-green;
+  }
+
+  &--closed {
+    background: rgba(vars.$gray1, 0.4);
+    color: vars.$gray3;
+  }
+
+  &__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    .cycle-status-banner--open & {
+      background: vars.$dark-green;
+    }
+
+    .cycle-status-banner--closed & {
+      background: vars.$gray2;
+    }
+  }
+
+  &__text {
+    line-height: 1;
+  }
+}

--- a/components/Topbar/index.jsx
+++ b/components/Topbar/index.jsx
@@ -1,16 +1,30 @@
-'use client';
+"use client";
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { useState, useEffect } from 'react';
-import NavigationItem from './NavigationItem';
-import ProfileDropdown from './ProfileDropdown';
-import Config from '@/lib/config';
-import './styles.scss';
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState, useEffect } from "react";
+import { useAtomValue } from "jotai";
+import NavigationItem from "./NavigationItem";
+import ProfileDropdown from "./ProfileDropdown";
+import Config from "@/lib/config";
+import { activeCommitteesAtom } from "@/lib/atoms";
+import "./styles.scss";
 
-export default function Topbar({ isAdmin, picture, onLogout, isRealAdmin, adminView, onToggleAdminView, isOfficer, officerView, onToggleOfficerView }) {
+export default function Topbar({
+  isAdmin,
+  picture,
+  onLogout,
+  isRealAdmin,
+  adminView,
+  onToggleAdminView,
+  isOfficer,
+  officerView,
+  onToggleOfficerView,
+}) {
   const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
+  const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const showInternship = isRealAdmin || isOfficer || (activeCommittees !== null && activeCommittees.length > 0);
 
   useEffect(() => {
     const handleResize = () => {
@@ -19,8 +33,8 @@ export default function Topbar({ isAdmin, picture, onLogout, isRealAdmin, adminV
       }
     };
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, [menuOpen]);
 
   const toggleMenu = () => {
@@ -29,21 +43,26 @@ export default function Topbar({ isAdmin, picture, onLogout, isRealAdmin, adminV
 
   const sharedLinks = (
     <>
-      <Link href="/home" className={pathname === '/home' ? 'selected' : ''}>
+      <Link href="/home" className={pathname === "/home" ? "selected" : ""}>
         <NavigationItem text="Home" />
       </Link>
-      <Link href="/events" className={pathname === '/events' ? 'selected' : ''}>
+      <Link href="/events" className={pathname === "/events" ? "selected" : ""}>
         <NavigationItem text="Events" />
       </Link>
-      <Link href="/leaderboard" className={pathname === '/leaderboard' ? 'selected' : ''}>
-        <NavigationItem text={isAdmin ? 'Members' : 'Leaderboard'} />
+      <Link href="/leaderboard" className={pathname === "/leaderboard" ? "selected" : ""}>
+        <NavigationItem text={isAdmin ? "Members" : "Leaderboard"} />
       </Link>
-      <Link href="/profile/career" className={pathname.startsWith('/profile/career') ? 'selected' : ''}>
+      <Link href="/profile/career" className={pathname.startsWith("/profile/career") ? "selected" : ""}>
         <NavigationItem text="Career Hub" />
       </Link>
-      <Link href="/resources" className={pathname === '/resources' ? 'selected' : ''}>
-        <NavigationItem text={isAdmin ? 'Organization' : 'Resources'} />
+      <Link href="/resources" className={pathname === "/resources" ? "selected" : ""}>
+        <NavigationItem text={isAdmin ? "Organization" : "Resources"} />
       </Link>
+      {showInternship && (
+        <Link href="/internship" className={pathname.startsWith("/internship") ? "selected" : ""}>
+          <NavigationItem text="Internship" />
+        </Link>
+      )}
     </>
   );
 
@@ -55,20 +74,19 @@ export default function Topbar({ isAdmin, picture, onLogout, isRealAdmin, adminV
           <img src="/new_acm_wordmark_chapter.png" alt={Config.organization.name} />
         </div>
 
-        <div className={`topbar-links ${menuOpen ? 'open' : ''}`}>
+        <div className={`topbar-links ${menuOpen ? "open" : ""}`}>
           {sharedLinks}
 
           {(isRealAdmin || isOfficer) && adminView && (
-            <Link href="/controlpanel" className={pathname === '/controlpanel' ? 'selected' : ''}>
+            <Link href="/controlpanel" className={pathname === "/controlpanel" ? "selected" : ""}>
               <NavigationItem text="Control Panel" />
             </Link>
           )}
-
         </div>
 
         {/* Hamburger Button (Mobile only) */}
-        <div className={`hamburger ${menuOpen ? 'open' : ''}`} onClick={toggleMenu}>
-          <i className={`fa ${menuOpen ? 'fa-times' : 'fa-bars'}`} />
+        <div className={`hamburger ${menuOpen ? "open" : ""}`} onClick={toggleMenu}>
+          <i className={`fa ${menuOpen ? "fa-times" : "fa-bars"}`} />
         </div>
 
         {/* Profile Icon (Desktop only) */}


### PR DESCRIPTION
## Description

Phase 3: Global Navigation & UI

Integrating the portal with the wider application.

- Topbar Integration: Add the "Internship" link to components/Topbar/index.jsx. Subtly hide it for members if activeCommitteesAtom is empty, but always show for staff.
- Career Hub Activation: Update the "Committee Applications" card in app/profile/CareerLanding.jsx to be active, including the dynamic "Open/Closed" status indicators.
- CycleStatusBanner: Build a global component to display the current recruitment cycle status across all dashboards.

## Related Issue

Resolves #311 

## Steps to view & test changes:

- Log in as admin/officer → confirm "Internship" link appears in topbar
- Log in as member → confirm "Internship" link is hidden when no active committees
- Navigate to /profile/career → confirm Committee Applications card is active with Open/Closed badge

## How Has This Been Tested?

- [x] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
<img width="1920" height="1006" alt="SCR-20260519-plrz" src="https://github.com/user-attachments/assets/276d7269-e8ff-441c-afc5-54192d3b6234" />
<img width="1920" height="1004" alt="SCR-20260519-plxs" src="https://github.com/user-attachments/assets/d3be41ae-2854-4484-ab84-ab0c6a8c3550" />
<img width="1539" height="577" alt="SCR-20260519-plza" src="https://github.com/user-attachments/assets/e2c25b04-7890-40a8-a1ee-f065831901c2" />
