### PR TITLE
Feat: Add filter dropdowns for admin/officer leaderboard view

### DIFF
--- a/app/actions/leaderboard/fetchAdminLeaderboard.ts
+++ b/app/actions/leaderboard/fetchAdminLeaderboard.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+
+interface AdminLeaderboardFilters {
+  year?: string;
+  role?: string;
+  committee?: string;
+}
+
+interface AdminLeaderboardResponse {
+  leaderboard: any[];
+}
+
+export default async function fetchAdminLeaderboard(
+  filters: AdminLeaderboardFilters = {}
+): Promise<AdminLeaderboardResponse> {
+  try {
+    const cks = await cookies();
+    const params = new URLSearchParams();
+
+    if (filters.year) params.set("year", filters.year);
+    if (filters.role) params.set("role", filters.role);
+    if (filters.committee) params.set("committee", filters.committee);
+
+    const query = params.toString();
+    const url = Config.API_URL + Config.routes.leaderboardAdmin + (query ? `?${query}` : "");
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${cks.get("token")?.value}`,
+      },
+    });
+
+    const data = await response.json();
+    if (!data || data.error) throw new Error(data?.error?.message ?? "Failed to fetch admin leaderboard");
+
+    return {
+      leaderboard: data.leaderboard ?? [],
+    };
+  } catch (err) {
+    Logger.error(`Fetch admin leaderboard failed: ${(err as Error).message}`);
+    throw err;
+  }
+}

--- a/app/leaderboard/AdminFilterBar/index.jsx
+++ b/app/leaderboard/AdminFilterBar/index.jsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import { useCallback } from 'react';
+import FilterDropdown from '@/components/FilterDropdown';
+import Config from '@/lib/config';
+import './style.scss';
+
+// Values correspond to the `year` integer field in the User model (1-5).
+const YEAR_OPTIONS = [
+  { value: '1', label: 'Freshman' },
+  { value: '2', label: 'Sophomore' },
+  { value: '3', label: 'Junior' },
+  { value: '4', label: 'Senior' },
+  { value: '5', label: 'Post-Senior' },
+];
+const ROLE_OPTIONS = ['MEMBER', 'OFFICER', 'ADMIN'];
+
+/**
+ * Filter bar for the admin/officer leaderboard view.
+ * Officers see only the Year dropdown; admins see Committee, Year, and Role.
+ * Filter state is stored in URL search params so selections survive page refreshes.
+ */
+export default function AdminFilterBar({ isAdmin }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const selectedYear = searchParams.getAll('year');
+  const selectedRole = searchParams.getAll('role');
+  const selectedCommittee = searchParams.getAll('committee');
+
+  const updateParams = useCallback(
+    (key, values) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete(key);
+      values.forEach((v) => params.append(key, v));
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [searchParams, router, pathname]
+  );
+
+  return (
+    <div className="admin-filter-bar">
+      <h2 className="admin-filter-bar-title">Members</h2>
+      <div className="admin-filter-bar-filters">
+        {isAdmin && (
+          <FilterDropdown
+            label="Committee"
+            options={Config.committees}
+            selected={selectedCommittee}
+            onChange={(vals) => updateParams('committee', vals)}
+          />
+        )}
+        <FilterDropdown
+          label="Year"
+          options={YEAR_OPTIONS}
+          selected={selectedYear}
+          onChange={(vals) => updateParams('year', vals)}
+        />
+        {isAdmin && (
+          <FilterDropdown
+            label="Role"
+            options={ROLE_OPTIONS}
+            selected={selectedRole}
+            onChange={(vals) => updateParams('role', vals)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/leaderboard/AdminFilterBar/style.scss
+++ b/app/leaderboard/AdminFilterBar/style.scss
@@ -1,0 +1,34 @@
+@use "@/styles/vars";
+
+.admin-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+
+  .admin-filter-bar-title {
+    font-size: 1.4em;
+    font-weight: bold;
+    color: vars.$primaryblack;
+    margin: 0;
+  }
+
+  .admin-filter-bar-filters {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-left: auto;
+  }
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .admin-filter-bar-filters {
+      width: 100%;
+    }
+  }
+}

--- a/app/leaderboard/leaderboard.jsx
+++ b/app/leaderboard/leaderboard.jsx
@@ -62,7 +62,16 @@ class Leaderboard extends React.Component {
   };
 
   render() {
-    if (!this.props.leaderboard || !this.props.leaderboard.length || this.props.leaderboard.length < 3) return null;
+    const adminView = this.props.showAdminView;
+    if (!adminView && (!this.props.leaderboard || !this.props.leaderboard.length || this.props.leaderboard.length < 3)) return null;
+    if (adminView && (!this.props.leaderboard || !this.props.leaderboard.length)) {
+      return (
+        <div className="leaderboard-wrapper">
+          {this.props.filterBar}
+          <p style={{ color: '#666', marginTop: 20 }}>No members found matching the selected filters.</p>
+        </div>
+      );
+    }
     if (this.props.error) {
       return (
         <div className="leaderboard-wrapper">
@@ -81,12 +90,16 @@ class Leaderboard extends React.Component {
             opened={this.state.openedModal}
             onChange={this.modalToggle}
           />
-          <div className="top-users">
-            <TopUser user={this.props.leaderboard[1]} place={2} onChange={this.updateModalInfo} />
-            <TopUser user={this.props.leaderboard[0]} place={1} onChange={this.updateModalInfo} />
-            <TopUser user={this.props.leaderboard[2]} place={3} onChange={this.updateModalInfo} />
-          </div>
-          <table className="leaderboard-table">
+          {adminView ? (
+            this.props.filterBar
+          ) : (
+            <div className="top-users">
+              <TopUser user={this.props.leaderboard[1]} place={2} onChange={this.updateModalInfo} />
+              <TopUser user={this.props.leaderboard[0]} place={1} onChange={this.updateModalInfo} />
+              <TopUser user={this.props.leaderboard[2]} place={3} onChange={this.updateModalInfo} />
+            </div>
+          )}
+          <table className={`leaderboard-table${adminView ? ' admin-view' : ''}`}>
             <thead>
               <tr>
                 <td>#</td>
@@ -102,9 +115,9 @@ class Leaderboard extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {this.props.leaderboard.slice(3, 3 + this.state.maxItems).map((user, i) => (
+              {this.props.leaderboard.slice(adminView ? 0 : 3, (adminView ? 0 : 3) + this.state.maxItems).map((user, i) => (
                 <tr className={user.firstName === this.props.user?.firstName && user.lastName === this.props.user?.lastName ? "current-user" : ""} key={i}>
-                  <td>{i + 4}</td>
+                  <td>{i + (adminView ? 1 : 4)}</td>
                   <td className="name">
                     <div className="inner-name">
                       <LeaderboardPicture

--- a/app/leaderboard/page.jsx
+++ b/app/leaderboard/page.jsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
+import { useSearchParams } from 'next/navigation';
 import Topbar from '@/components/Topbar';
 import Leaderboard from './leaderboard';
+import AdminFilterBar from './AdminFilterBar';
 import logoutUser from '@/app/actions/auth/logoutUser';
 import fetchLeaderboard from '@/app/actions/leaderboard/fetchLeaderboard';
+import fetchAdminLeaderboard from '@/app/actions/leaderboard/fetchAdminLeaderboard';
 import { authUserProfileAtom, isAdminAtom, isOfficerAtom, adminViewAtom, officerViewAtom } from '@/lib/atoms';
 
-export default function LeaderboardPage() {
+// Wrapped in Suspense because useSearchParams() requires it in Next.js App Router.
+function LeaderboardPageInner() {
   const userProfile = useAtomValue(authUserProfileAtom);
   const isAdmin = useAtomValue(isAdminAtom);
   const isOfficer = useAtomValue(isOfficerAtom);
@@ -17,13 +21,30 @@ export default function LeaderboardPage() {
   const [leaderboard, setLeaderboard] = useState([]);
   const [error, setError] = useState(null);
   const [mounted, setMounted] = useState(false);
+  const searchParams = useSearchParams();
+
+  // Both admins and officers use the same adminView toggle — the backend and
+  // AdminFilterBar handle permission differences (which filters are visible).
+  const showAdminView = (isAdmin || isOfficer) && adminView;
 
   useEffect(() => {
     const loadLeaderboard = async () => {
       setMounted(true);
       try {
-        const leaderboard = await fetchLeaderboard();
-        setLeaderboard(leaderboard);
+        if (showAdminView) {
+          const filters = {};
+          const year = searchParams.get('year');
+          const role = searchParams.get('role');
+          const committee = searchParams.get('committee');
+          if (year) filters.year = year;
+          if (role) filters.role = role;
+          if (committee) filters.committee = committee;
+          const result = await fetchAdminLeaderboard(filters);
+          setLeaderboard(result.leaderboard);
+        } else {
+          const result = await fetchLeaderboard();
+          setLeaderboard(result);
+        }
       } catch (err) {
         console.error('Failed to load leaderboard:', err);
         setError('Failed to load leaderboard');
@@ -31,7 +52,8 @@ export default function LeaderboardPage() {
     };
 
     loadLeaderboard();
-  }, []);
+  // Re-fetches when the view mode toggles or any filter param changes in the URL.
+  }, [showAdminView, searchParams]);
 
   const handleLogout = async () => {
     await logoutUser();
@@ -59,7 +81,17 @@ export default function LeaderboardPage() {
         user={userProfile}
         error={error}
         isAdmin={isAdmin && adminView}
+        showAdminView={showAdminView}
+        filterBar={showAdminView ? <AdminFilterBar isAdmin={isAdmin} /> : null}
       />
     </div>
+  );
+}
+
+export default function LeaderboardPage() {
+  return (
+    <Suspense>
+      <LeaderboardPageInner />
+    </Suspense>
   );
 }

--- a/app/leaderboard/style.scss
+++ b/app/leaderboard/style.scss
@@ -191,6 +191,20 @@
       }
     }
 
+    &.admin-view {
+      thead tr td.name div {
+        text-align: left;
+
+        img {
+          display: none;
+        }
+      }
+
+      tr td.name .inner-name .profile-pic {
+        display: none;
+      }
+    }
+
     @media (max-width: 450px) {
       tr td.name div img {
         display: none;

--- a/components/FilterDropdown/index.jsx
+++ b/components/FilterDropdown/index.jsx
@@ -1,0 +1,100 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import './style.scss';
+
+/**
+ * Reusable dropdown filter component.
+ *
+ * @param {string} label - Placeholder text shown when nothing is selected.
+ * @param {Array<string|{value: string, label: string}>} options - Items to display.
+ * @param {string[]} selected - Currently selected values (controlled).
+ * @param {(values: string[]) => void} onChange - Called with the new selection array.
+ * @param {boolean} multiSelect - If true, allows multiple selections with checkboxes.
+ */
+export default function FilterDropdown({
+  label,
+  options = [],
+  selected = [],
+  onChange,
+  multiSelect = false,
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (value) => {
+    if (multiSelect) {
+      const next = selected.includes(value)
+        ? selected.filter((v) => v !== value)
+        : [...selected, value];
+      onChange(next);
+    } else {
+      onChange(selected.includes(value) ? [] : [value]);
+      setOpen(false);
+    }
+  };
+
+  const handleClear = (e) => {
+    e.stopPropagation();
+    onChange([]);
+  };
+
+  const getDisplayLabel = () => {
+    if (selected.length === 0) return label;
+    const selectedLabels = selected.map((val) => {
+      const opt = options.find((o) => (typeof o === 'string' ? o : o.value) === val);
+      return opt ? (typeof opt === 'string' ? opt : opt.label) : val;
+    });
+    return selectedLabels.join(', ');
+  };
+  const displayLabel = getDisplayLabel();
+
+  return (
+    <div className="filter-dropdown" ref={ref}>
+      <button
+        type="button"
+        className={`filter-dropdown-toggle ${open ? 'open' : ''} ${selected.length > 0 ? 'active' : ''}`}
+        onClick={() => setOpen(!open)}
+      >
+        <span className="filter-dropdown-label">{displayLabel}</span>
+        {selected.length > 0 && (
+          <span className="filter-dropdown-clear" onClick={handleClear}>
+            &times;
+          </span>
+        )}
+        <i className={`fa fa-chevron-down filter-dropdown-chevron ${open ? 'rotated' : ''}`} aria-hidden="true" />
+      </button>
+      {open && (
+        <ul className="filter-dropdown-menu">
+          {options.map((opt) => {
+            const value = typeof opt === 'string' ? opt : opt.value;
+            const optLabel = typeof opt === 'string' ? opt : opt.label;
+            const isSelected = selected.includes(value);
+            return (
+              <li
+                key={value}
+                className={`filter-dropdown-item ${isSelected ? 'selected' : ''}`}
+                onClick={() => handleSelect(value)}
+              >
+                {multiSelect && (
+                  <span className={`filter-dropdown-check ${isSelected ? 'checked' : ''}`} />
+                )}
+                <span>{optLabel}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/FilterDropdown/style.scss
+++ b/components/FilterDropdown/style.scss
@@ -1,0 +1,126 @@
+@use "@/styles/vars";
+
+.filter-dropdown {
+  position: relative;
+  display: inline-block;
+
+  .filter-dropdown-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 12px;
+    border-radius: 12px;
+    border: 1px solid vars.$gray1;
+    background: white;
+    font-family: "Open Sans", sans-serif;
+    font-size: 14px;
+    color: vars.$gray3;
+    cursor: pointer;
+    outline: none;
+    white-space: nowrap;
+
+    &:hover,
+    &.open {
+      border-color: vars.$secondaryblue;
+    }
+
+    &.active {
+      border-color: vars.$secondaryblue;
+      background: rgba(vars.$secondaryblue, 0.06);
+    }
+  }
+
+  .filter-dropdown-label {
+    flex: 1;
+  }
+
+  .filter-dropdown-clear {
+    font-size: 16px;
+    line-height: 1;
+    color: vars.$gray2;
+    cursor: pointer;
+
+    &:hover {
+      color: vars.$gray3;
+    }
+  }
+
+  .filter-dropdown-chevron {
+    font-size: 10px;
+    color: vars.$gray2;
+    transition: transform 0.15s ease;
+
+    &.rotated {
+      transform: rotate(180deg);
+    }
+  }
+
+  .filter-dropdown-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 100%;
+    max-height: 240px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    margin: 0;
+    padding: 4px 0;
+    list-style: none;
+    background: white;
+    border: 1px solid vars.$gray1;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 100;
+
+    li.filter-dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      font-size: 14px;
+      color: vars.$gray3;
+      background: white;
+      border: none;
+      border-radius: 0;
+      cursor: pointer;
+
+      &:hover {
+        background: rgba(vars.$secondaryblue, 0.06);
+      }
+
+      &.selected {
+        color: vars.$secondaryblue;
+        font-weight: 600;
+        background: rgba(vars.$secondaryblue, 0.06);
+      }
+    }
+  }
+
+  .filter-dropdown-check {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 1.5px solid vars.$gray1;
+    border-radius: 3px;
+    flex-shrink: 0;
+
+    &.checked {
+      border-color: vars.$secondaryblue;
+      background: vars.$secondaryblue;
+      position: relative;
+
+      &::after {
+        content: "";
+        position: absolute;
+        left: 4px;
+        top: 1px;
+        width: 5px;
+        height: 9px;
+        border: solid white;
+        border-width: 0 2px 2px 0;
+        transform: rotate(45deg);
+      }
+    }
+  }
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -42,6 +42,7 @@ const config = {
       committeesBulkStatus: "/api/v1/internship/committees/bulk-status",
     },
     leaderboard: "/api/v1/leaderboard",
+    leaderboardAdmin: "/api/v1/leaderboard/admin",
     admin: {
       promote: "/api/v1/admin/promote",
       promoteOfficer: "/api/v1/admin/promote-officer",


### PR DESCRIPTION
## Description

Added dropdown filter components to the admin/officer leaderboard view.

### Frontend Changes
- Added a reusable `FilterDropdown` component with multi-select-ready support
- Added an `AdminFilterBar` component that conditionally renders filters based on user access type
  - Officers see:
    - Year filter only
  - Admins see:
    - Committee filter
    - Year filter
    - Role filter
- Filter selections are stored in URL search params so they persist across refreshes
- Updating filters triggers a leaderboard re-fetch
- Added clear (`×`) functionality to reset individual filters
- Ensured the filter bar remains usable on smaller viewport sizes

### Backend Changes
- Added new `/leaderboard/admin` endpoint supporting:
  - `?year=`
  - `?committee=`
  - `?role=`
- Added shared `buildAdminLeaderboardQuery` helper to build Sequelize `where` clauses
- Officers are restricted to viewing `STANDARD` members only
- Admins can view all access types

## Related Issue

Resolves #282

## Steps to view & test changes:

- Log in as an [admin](https://wiki.uclaacm.com/doc/membership-portal-zXucs8mbPS?q=admin) (link to Dev Team Documentation)
- Toggle to admin view on the leaderboard
- Verify Committee, Year, and Role dropdowns all appear

- Select a filter (e.g. Year → Freshman)
- Verify the table updates to show only matching members

- Refresh the page
- Verify the selected filter persists in the URL

- Clear a filter using the `×` button
- Verify the table resets

- Log in as an officer (refer to documentation again)
- Toggle to officer view
- Verify only the Year dropdown appears
- Verify Committee and Role dropdowns are not visible

- Resize the browser window
- Verify the filter bar remains usable on smaller viewports

## How Has This Been Tested?

- [x] Manual tests
- [x] Responsive View

## Screenshots (if appropriate)
Officer View
<img width="1512" height="837" alt="image" src="https://github.com/user-attachments/assets/c2c910ed-aa69-4d76-aa53-91c584b01232" />

Admin Views
<img width="1512" height="837" alt="image" src="https://github.com/user-attachments/assets/2e4bc6ea-dc78-479d-8835-6cfcfac6071f" />
<img width="1512" height="837" alt="image" src="https://github.com/user-attachments/assets/d97cbb22-4aec-450f-b2c2-7f5c07f9eb57" />

