### PR TITLE
feat: Application Oversight (Phase 2)

### DIFF
--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -2,7 +2,9 @@
 
 import { useCallback, useEffect, useState } from "react";
 import CommitteeTable from "@/components/Internship/CommitteeTable";
+import ApplicationTable from "@/components/Internship/ApplicationTable";
 import fetchCommittees from "@/app/actions/internship/fetchCommittees";
+import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
 import "./AdminDashboard.scss";
 
 const TABS = [
@@ -15,6 +17,10 @@ export default function AdminDashboard() {
   const [committees, setCommittees] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [applications, setApplications] = useState([]);
+  const [applicationsLoading, setApplicationsLoading] = useState(false);
+  const [applicationsError, setApplicationsError] = useState(null);
+  const [applicationsLoaded, setApplicationsLoaded] = useState(false);
 
   const loadCommittees = useCallback(async () => {
     setLoading(true);
@@ -28,9 +34,28 @@ export default function AdminDashboard() {
     setLoading(false);
   }, []);
 
+  const loadApplications = useCallback(async () => {
+    setApplicationsLoading(true);
+    const result = await fetchAllApplications();
+    if (result.success) {
+      setApplications(result.data);
+      setApplicationsError(null);
+    } else {
+      setApplicationsError(result.error);
+    }
+    setApplicationsLoading(false);
+    setApplicationsLoaded(true);
+  }, []);
+
   useEffect(() => {
     Promise.resolve().then(loadCommittees);
   }, [loadCommittees]);
+
+  useEffect(() => {
+    if (activeTab === "applications" && !applicationsLoaded && !applicationsLoading) {
+      Promise.resolve().then(loadApplications);
+    }
+  }, [activeTab, applicationsLoaded, applicationsLoading, loadApplications]);
 
   return (
     <div className="admin-dashboard">
@@ -65,9 +90,17 @@ export default function AdminDashboard() {
           </>
         )}
         {activeTab === "applications" && (
-          <div className="admin-dashboard__placeholder">
-            Application oversight will appear here in Phase 2.
-          </div>
+          <>
+            {applicationsLoading && (
+              <div className="admin-dashboard__placeholder">Loading applications…</div>
+            )}
+            {!applicationsLoading && applicationsError && (
+              <div className="committee-table-wrapper__error">{applicationsError}</div>
+            )}
+            {!applicationsLoading && !applicationsError && (
+              <ApplicationTable applications={applications} committees={committees} />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -18,9 +18,8 @@ export default function AdminDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [applications, setApplications] = useState([]);
-  const [applicationsLoading, setApplicationsLoading] = useState(false);
+  const [applicationsStatus, setApplicationsStatus] = useState("idle");
   const [applicationsError, setApplicationsError] = useState(null);
-  const [applicationsLoaded, setApplicationsLoaded] = useState(false);
 
   const loadCommittees = useCallback(async () => {
     setLoading(true);
@@ -35,16 +34,16 @@ export default function AdminDashboard() {
   }, []);
 
   const loadApplications = useCallback(async () => {
-    setApplicationsLoading(true);
+    setApplicationsStatus("loading");
     const result = await fetchAllApplications();
     if (result.success) {
       setApplications(result.data);
       setApplicationsError(null);
+      setApplicationsStatus("success");
     } else {
       setApplicationsError(result.error);
+      setApplicationsStatus("error");
     }
-    setApplicationsLoading(false);
-    setApplicationsLoaded(true);
   }, []);
 
   useEffect(() => {
@@ -52,10 +51,10 @@ export default function AdminDashboard() {
   }, [loadCommittees]);
 
   useEffect(() => {
-    if (activeTab === "applications" && !applicationsLoaded && !applicationsLoading) {
+    if (activeTab === "applications" && applicationsStatus === "idle") {
       Promise.resolve().then(loadApplications);
     }
-  }, [activeTab, applicationsLoaded, applicationsLoading, loadApplications]);
+  }, [activeTab, applicationsStatus, loadApplications]);
 
   return (
     <div className="admin-dashboard">
@@ -91,13 +90,21 @@ export default function AdminDashboard() {
         )}
         {activeTab === "applications" && (
           <>
-            {applicationsLoading && (
+            {applicationsStatus === "loading" && (
               <div className="admin-dashboard__placeholder">Loading applications…</div>
             )}
-            {!applicationsLoading && applicationsError && (
-              <div className="committee-table-wrapper__error">{applicationsError}</div>
+            {applicationsStatus === "error" && (
+              <div className="committee-table-wrapper__error">
+                {applicationsError}
+                <button
+                  type="button"
+                  onClick={() => setApplicationsStatus("idle")}
+                >
+                  Retry
+                </button>
+              </div>
             )}
-            {!applicationsLoading && !applicationsError && (
+            {applicationsStatus === "success" && (
               <ApplicationTable applications={applications} committees={committees} />
             )}
           </>

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -154,6 +154,127 @@
   }
 }
 
+.application-table-wrapper {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  &__count {
+    color: vars.$gray3;
+    font-size: 0.85rem;
+  }
+
+  &__empty {
+    padding: 2rem;
+    text-align: center;
+    color: vars.$gray3;
+  }
+}
+
+.application-filters {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  &__search {
+    flex: 1 1 220px;
+    min-width: 200px;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    font-size: 0.9rem;
+
+    &:focus {
+      outline: none;
+      border-color: vars.$primary-color;
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+
+    select {
+      padding: 0.45rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      background: vars.$white;
+      font-size: 0.9rem;
+      min-width: 160px;
+
+      &:focus {
+        outline: none;
+        border-color: vars.$primary-color;
+      }
+    }
+  }
+
+  &__label {
+    color: vars.$gray3;
+    font-weight: 500;
+  }
+}
+
+.application-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.75rem 0.5rem;
+    border-bottom: 1px solid vars.$gray1;
+    vertical-align: top;
+  }
+
+  th {
+    font-weight: 600;
+    color: vars.$gray3;
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  tr:hover td {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  &__committees,
+  &__status-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__committee,
+  &__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+  }
+
+  &__rank {
+    display: inline-block;
+    min-width: 28px;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.06);
+    color: vars.$gray3;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-align: center;
+  }
+}
+
 .bulk-action-bar {
   display: flex;
   align-items: center;

--- a/components/Internship/ApplicationTable.jsx
+++ b/components/Internship/ApplicationTable.jsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+function formatDate(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function applicationStatuses(application) {
+  return [
+    application.firstChoiceStatus,
+    application.secondChoiceStatus,
+    application.thirdChoiceStatus,
+  ].filter(Boolean);
+}
+
+function applicationCommittees(application) {
+  return [
+    application.firstChoiceCommittee,
+    application.secondChoiceCommittee,
+    application.thirdChoiceCommittee,
+  ].filter(Boolean);
+}
+
+export default function ApplicationTable({ applications = [], committees = [] }) {
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [committeeFilter, setCommitteeFilter] = useState("all");
+
+  const committeeLookup = useMemo(() => {
+    const map = new Map();
+    committees.forEach(c => map.set(c.id, c.displayName ?? c.name));
+    return map;
+  }, [committees]);
+
+  const statusOptions = useMemo(() => {
+    const set = new Set();
+    applications.forEach(app => {
+      applicationStatuses(app).forEach(s => set.add(s));
+    });
+    return Array.from(set).sort();
+  }, [applications]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return applications.filter(app => {
+      if (term) {
+        const haystack = `${app.firstName ?? ""} ${app.lastName ?? ""} ${app.email ?? ""}`.toLowerCase();
+        if (!haystack.includes(term)) return false;
+      }
+
+      if (statusFilter !== "all" && !applicationStatuses(app).includes(statusFilter)) {
+        return false;
+      }
+
+      if (committeeFilter !== "all" && !applicationCommittees(app).includes(committeeFilter)) {
+        return false;
+      }
+
+      return true;
+    });
+  }, [applications, search, statusFilter, committeeFilter]);
+
+  return (
+    <div className="application-table-wrapper">
+      <div className="application-table-wrapper__header">
+        <h3>Applications</h3>
+        <span className="application-table-wrapper__count">
+          {filtered.length} of {applications.length}
+        </span>
+      </div>
+
+      <div className="application-filters">
+        <input
+          type="search"
+          className="application-filters__search"
+          placeholder="Search by name or email"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          aria-label="Search applications"
+        />
+
+        <label className="application-filters__field">
+          <span className="application-filters__label">Status</span>
+          <select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            {statusOptions.map(status => (
+              <option key={status} value={status}>
+                {status}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="application-filters__field">
+          <span className="application-filters__label">Committee</span>
+          <select
+            value={committeeFilter}
+            onChange={e => setCommitteeFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            {committees.map(c => (
+              <option key={c.id} value={c.id}>
+                {c.displayName ?? c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="application-table-wrapper__empty">
+          {applications.length === 0
+            ? "No applications yet."
+            : "No applications match the current filters."}
+        </div>
+      ) : (
+        <table className="application-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Email</th>
+              <th>University</th>
+              <th>Major</th>
+              <th>Grad Year</th>
+              <th>Committees</th>
+              <th>Status</th>
+              <th>Submitted</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(app => (
+              <tr key={app._id}>
+                <td>
+                  {app.firstName} {app.lastName}
+                </td>
+                <td>{app.email}</td>
+                <td>{app.university}</td>
+                <td>{app.major}</td>
+                <td>{app.graduationYear ?? "—"}</td>
+                <td>
+                  <div className="application-table__committees">
+                    {[
+                      { id: app.firstChoiceCommittee, rank: "1st" },
+                      { id: app.secondChoiceCommittee, rank: "2nd" },
+                      { id: app.thirdChoiceCommittee, rank: "3rd" },
+                    ]
+                      .filter(c => c.id)
+                      .map(c => (
+                        <span key={c.rank} className="application-table__committee">
+                          <span className="application-table__rank">{c.rank}</span>
+                          {committeeLookup.get(c.id) ?? c.id}
+                        </span>
+                      ))}
+                  </div>
+                </td>
+                <td>
+                  <div className="application-table__status-list">
+                    {[
+                      { rank: "1st", status: app.firstChoiceStatus },
+                      { rank: "2nd", status: app.secondChoiceStatus },
+                      { rank: "3rd", status: app.thirdChoiceStatus },
+                    ]
+                      .filter(s => s.status)
+                      .map(s => (
+                        <span key={s.rank} className="application-table__status">
+                          <span className="application-table__rank">{s.rank}</span>
+                          {s.status}
+                        </span>
+                      ))}
+                  </div>
+                </td>
+                <td>{formatDate(app.submittedAt)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

- Adds an admin-facing **Applications** view to the internship admin dashboard, replacing the Phase-1 placeholder on the "Applications" tab.
- Adds `ApplicationTable.jsx` — a cross-committee, unscoped view of every submitted application with built-in filtering.
- Lazy-loads applications via the existing `fetchAllApplications` server action only when the tab is opened, so the Committees tab still renders without an extra round trip.

## Related Issue

Resolves #319 

## Steps to view & test changes:

- Log in as an admin and visit /internship/admin — Committees tab is selected by default
- Click the Applications tab — loading state appears, then the table renders (or empty state if no apps exist)

## How Has This Been Tested?

- [X] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
