### PR TITLE
Phase 3 & 4: Step 2 — Dynamic Question Rendering & Auto-Save Engine

### DIFF
--- a/components/Internship/ApplicationWizard/Step1Committees/index.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/index.jsx
@@ -156,7 +156,8 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
       <div className="text-xs text-slate-500 text-right">
         {saveState === "pending" && "Saving…"}
         {saveState === "saving" && "Saving…"}
-        {saveState === "idle" && myApplication?._id && "Saved"}
+        {saveState === "idle" && myApplication?._id &&
+          `Saved${myApplication.lastModifiedAt ? ` ${new Date(myApplication.lastModifiedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`}
         {saveState === "error" && (
           <span className="text-red-600">
             {error || "Save failed"}{" "}

--- a/components/Internship/ApplicationWizard/Step1Committees/useStep1Save.js
+++ b/components/Internship/ApplicationWizard/Step1Committees/useStep1Save.js
@@ -5,21 +5,37 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import createApplicationDraft from "@/app/actions/internship/createApplicationDraft";
 import updateApplication from "@/app/actions/internship/updateApplication";
-import { myApplicationAtom } from "@/lib/atoms";
+import { myApplicationAtom, responsesByCommitteeAtom } from "@/lib/atoms";
 
 const DEBOUNCE_MS = 500;
 
-function buildBody(ids) {
+function buildBody(ids, responsesMap) {
   const [first, second, third] = ids;
-  return {
+  const body = {
     firstChoiceCommittee: first,
     secondChoiceCommittee: second ?? null,
     thirdChoiceCommittee: third ?? null,
   };
+  const hasMapEntries = responsesMap && Object.keys(responsesMap).length > 0;
+  if (hasMapEntries) {
+    const cleanResponses = (committeeId) => {
+      if (!committeeId) return [];
+      const arr = responsesMap[committeeId];
+      if (!Array.isArray(arr)) return [];
+      return arr
+        .filter((r) => r && typeof r.answer === "string" && r.answer.trim() !== "")
+        .map((r) => ({ questionKey: r.questionKey, question: r.question, answer: r.answer }));
+    };
+    body.firstChoiceResponses = cleanResponses(first);
+    body.secondChoiceResponses = cleanResponses(second);
+    body.thirdChoiceResponses = cleanResponses(third);
+  }
+  return body;
 }
 
 export default function useStep1Save(selectedCommitteeIds, profileData) {
   const [myApplication, setMyApplication] = useAtom(myApplicationAtom);
+  const [responsesByCommittee] = useAtom(responsesByCommitteeAtom);
   const [saveState, setSaveState] = useState("idle");
   const [error, setError] = useState(null);
   const [errorKind, setErrorKind] = useState(null);
@@ -31,6 +47,7 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
   const profileDataRef = useRef(profileData);
   const saveStateRef = useRef(saveState);
   const errorRef = useRef(error);
+  const responsesByCommitteeRef = useRef(responsesByCommittee);
   const hasEverSelectedRef = useRef(selectedCommitteeIds.length > 0);
 
   useEffect(() => {
@@ -53,6 +70,10 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
     errorRef.current = error;
   }, [error]);
 
+  useEffect(() => {
+    responsesByCommitteeRef.current = responsesByCommittee;
+  }, [responsesByCommittee]);
+
   const doSave = useCallback(async () => {
     const ids = latestIdsRef.current;
     const app = appRef.current;
@@ -69,8 +90,7 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
     setErrorKind(null);
 
     try {
-      const payload = buildBody(ids);
-      //console.log("Step1 committees payload:", payload);
+      const payload = buildBody(ids, responsesByCommitteeRef.current);
       if (!app || !app._id) {
         const pd = profileDataRef.current;
         if (!pd || !pd.university || !pd.major || typeof pd.graduationYear !== "number") {
@@ -96,7 +116,7 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
 
         const freshIds = latestIdsRef.current;
         if (freshIds.length > 1) {
-          const r2 = await updateApplication(result.data._id, buildBody(freshIds));
+          const r2 = await updateApplication(result.data._id, buildBody(freshIds, responsesByCommitteeRef.current));
           if (!r2.success) {
             if (r2.notFound) {
               setError("Application not found");

--- a/components/Internship/ApplicationWizard/Step2Questions/CommitteeTabBar.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/CommitteeTabBar.jsx
@@ -1,0 +1,43 @@
+"use client";
+
+function rankLabel(rank) {
+  if (rank === 1) return "1st";
+  if (rank === 2) return "2nd";
+  if (rank === 3) return "3rd";
+  return "";
+}
+
+export default function CommitteeTabBar({ tabs, activeIndex, onChange }) {
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="flex border-b border-slate-200" role="tablist">
+      {tabs.map((tab, index) => {
+        const isActive = activeIndex === index;
+        const className = isActive
+          ? "relative px-4 py-2 text-sm font-medium text-blue-600 border-b-2 border-blue-600"
+          : "relative px-4 py-2 text-sm font-medium text-slate-600 border-b-2 border-transparent hover:text-slate-900 hover:border-slate-300";
+        return (
+          <button
+            key={tab.committeeId}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(index)}
+            className={className}
+          >
+            <span>
+              {rankLabel(tab.rank)} • {tab.displayName}
+            </span>
+            {tab.incomplete && (
+              <span
+                className="ml-2 inline-block h-2 w-2 rounded-full bg-red-600"
+                aria-label="Incomplete"
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step2Questions/QuestionField.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/QuestionField.jsx
@@ -1,0 +1,66 @@
+"use client";
+
+export default function QuestionField({ question, value, onChange }) {
+  const currentValue = value ?? "";
+  const inputClass =
+    "mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600";
+
+  let field;
+  if (question.questionType === "short_text") {
+    field = (
+      <input
+        type="text"
+        value={currentValue}
+        onChange={(e) => onChange(e.target.value)}
+        className={inputClass}
+      />
+    );
+  } else if (question.questionType === "long_text") {
+    const atLimit = currentValue.length >= 2000;
+    field = (
+      <div className="space-y-1">
+        <textarea
+          value={currentValue}
+          onChange={(e) => onChange(e.target.value)}
+          maxLength={2000}
+          rows={5}
+          className={inputClass}
+        />
+        <div className={`text-xs ${atLimit ? "text-red-600" : "text-slate-500"}`}>
+          {currentValue.length} / 2000
+        </div>
+      </div>
+    );
+  } else if (question.questionType === "multiple_choice") {
+    if (!question.choices || question.choices.length === 0) {
+      field = <p className="text-sm italic text-slate-500">(no choices configured)</p>;
+    } else {
+      field = (
+        <div className="mt-1 space-y-2">
+          {question.choices.map((choice) => (
+            <label key={choice} className="flex items-center gap-2">
+              <input
+                type="radio"
+                name={question.questionKey}
+                value={choice}
+                checked={currentValue === choice}
+                onChange={() => onChange(choice)}
+              />
+              <span className="text-sm text-slate-800">{choice}</span>
+            </label>
+          ))}
+        </div>
+      );
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-slate-700">
+        {question.questionText}
+        {question.required && <span className="text-red-600">*</span>}
+      </label>
+      {field}
+    </div>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step2Questions/QuestionForm.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/QuestionForm.jsx
@@ -1,0 +1,29 @@
+"use client";
+
+import QuestionField from "./QuestionField";
+
+export default function QuestionForm({ questions, responses, onAnswerChange }) {
+  const sortedQuestions = [...questions].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  const answerByKey = new Map(responses.map((r) => [r.questionKey, r.answer]));
+
+  if (sortedQuestions.length === 0) {
+    return (
+      <p className="text-sm italic text-slate-500">
+        This committee has no application questions.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {sortedQuestions.map((q) => (
+        <QuestionField
+          key={q.questionKey}
+          question={q}
+          value={answerByKey.get(q.questionKey) ?? ""}
+          onChange={(a) => onAnswerChange(q.questionKey, a)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step2Questions/index.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/index.jsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
+
+import CommitteeTabBar from "./CommitteeTabBar";
+import QuestionForm from "./QuestionForm";
+import useStep2Save from "./useStep2Save";
+import { committeesAtom, myApplicationAtom, responsesByCommitteeAtom } from "@/lib/atoms";
+
+function getSelectedCommitteeIds(app) {
+  if (!app) return [];
+  return [app.firstChoiceCommittee, app.secondChoiceCommittee, app.thirdChoiceCommittee].filter(Boolean);
+}
+
+function getSlotResponses(app, slot) {
+  if (!app) return [];
+  if (slot === 0) return Array.isArray(app.firstChoiceResponses) ? app.firstChoiceResponses : [];
+  if (slot === 1) return Array.isArray(app.secondChoiceResponses) ? app.secondChoiceResponses : [];
+  if (slot === 2) return Array.isArray(app.thirdChoiceResponses) ? app.thirdChoiceResponses : [];
+  return [];
+}
+
+function isAnswered(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+export default function Step2Questions({ onValidityChange, flushPendingRef }) {
+  const myApplication = useAtomValue(myApplicationAtom);
+  const committees = useAtomValue(committeesAtom);
+  const [responsesByCommittee, setResponsesByCommittee] = useAtom(responsesByCommitteeAtom);
+
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const hydratedRef = useRef(false);
+
+  const selectedCommitteeIds = useMemo(() => getSelectedCommitteeIds(myApplication), [myApplication]);
+
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    if (!myApplication) return;
+    const ids = getSelectedCommitteeIds(myApplication);
+    if (ids.length === 0) return;
+    setResponsesByCommittee((prev) => {
+      const next = { ...prev };
+      ids.forEach((id, slot) => {
+        if (!next[id] || next[id].length === 0) {
+          next[id] = getSlotResponses(myApplication, slot);
+        }
+      });
+      return next;
+    });
+    hydratedRef.current = true;
+  }, [myApplication, setResponsesByCommittee]);
+
+  const safeActiveTabIndex =
+    activeTabIndex >= selectedCommitteeIds.length && selectedCommitteeIds.length > 0
+      ? 0
+      : activeTabIndex;
+
+  const committeeById = useMemo(() => {
+    const map = new Map();
+    committees.forEach((c) => { map.set(c.id, c); });
+    return map;
+  }, [committees]);
+
+  const isTabIncomplete = useCallback((committeeId) => {
+    const committee = committeeById.get(committeeId);
+    if (!committee || !Array.isArray(committee.customQuestions)) return false;
+    const responses = responsesByCommittee[committeeId] || [];
+    const answerByKey = new Map(responses.map((r) => [r.questionKey, r.answer]));
+    return committee.customQuestions.some((q) => q.required && !isAnswered(answerByKey.get(q.questionKey)));
+  }, [committeeById, responsesByCommittee]);
+
+  const tabs = useMemo(() => selectedCommitteeIds.map((id, idx) => {
+    const committee = committeeById.get(id);
+    return {
+      committeeId: id,
+      displayName: committee?.displayName ?? "Committee",
+      rank: idx + 1,
+      incomplete: isTabIncomplete(id),
+    };
+  }), [selectedCommitteeIds, committeeById, isTabIncomplete]);
+
+  const step2Valid = useMemo(() => {
+    if (selectedCommitteeIds.length === 0) return false;
+    return selectedCommitteeIds.every((id) => !isTabIncomplete(id));
+  }, [selectedCommitteeIds, isTabIncomplete]);
+
+  useEffect(() => {
+    onValidityChange(step2Valid);
+  }, [step2Valid, onValidityChange]);
+
+  const { saveState, error, errorKind, flushPending, retry } = useStep2Save(selectedCommitteeIds);
+
+  useEffect(() => {
+    if (flushPendingRef) flushPendingRef.current = flushPending;
+    return () => {
+      if (flushPendingRef) flushPendingRef.current = null;
+    };
+  }, [flushPendingRef, flushPending]);
+
+  const activeCommitteeId = selectedCommitteeIds[safeActiveTabIndex];
+  const activeCommittee = activeCommitteeId ? committeeById.get(activeCommitteeId) : null;
+  const activeQuestions = activeCommittee?.customQuestions ?? [];
+  const activeResponses = activeCommitteeId ? (responsesByCommittee[activeCommitteeId] || []) : [];
+
+  const handleAnswerChange = useCallback((questionKey, answer) => {
+    if (!activeCommitteeId) return;
+    setResponsesByCommittee((prev) => {
+      const current = prev[activeCommitteeId] || [];
+      const activeCommitteeData = committeeById.get(activeCommitteeId);
+      const question = activeCommitteeData?.customQuestions?.find((q) => q.questionKey === questionKey);
+      const questionText = question?.questionText ?? "";
+      const idx = current.findIndex((r) => r.questionKey === questionKey);
+      let nextArr;
+      if (idx === -1) {
+        nextArr = [...current, { questionKey, question: questionText, answer }];
+      } else {
+        nextArr = current.map((r, i) => (i === idx ? { ...r, answer } : r));
+      }
+      return { ...prev, [activeCommitteeId]: nextArr };
+    });
+  }, [activeCommitteeId, committeeById, setResponsesByCommittee]);
+
+  if (selectedCommitteeIds.length === 0) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-slate-900">Application questions</h2>
+        <p className="text-sm text-slate-600">Select at least one committee in Step 1 before answering questions.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Application questions</h2>
+        <p className="text-sm text-slate-600">Required questions are marked with a red asterisk.</p>
+      </div>
+
+      <CommitteeTabBar tabs={tabs} activeIndex={safeActiveTabIndex} onChange={setActiveTabIndex} />
+
+      {activeCommittee && (
+        <QuestionForm
+          questions={activeQuestions}
+          responses={activeResponses}
+          onAnswerChange={handleAnswerChange}
+        />
+      )}
+
+      <div className="text-xs text-slate-500 text-right">
+        {saveState === "pending" && "Saving…"}
+        {saveState === "saving" && "Saving…"}
+        {saveState === "idle" && myApplication?._id &&
+          `Saved${myApplication.lastModifiedAt ? ` ${new Date(myApplication.lastModifiedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`}
+        {saveState === "error" && (
+          <span className="text-red-600">
+            {error || "Save failed"}{" "}
+            <button type="button" onClick={retry} className="underline ml-1">Retry</button>
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step2Questions/useStep2Save.js
+++ b/components/Internship/ApplicationWizard/Step2Questions/useStep2Save.js
@@ -1,0 +1,208 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import updateApplication from "@/app/actions/internship/updateApplication";
+import { myApplicationAtom, responsesByCommitteeAtom } from "@/lib/atoms";
+
+const DEBOUNCE_MS = 500;
+
+function cleanResponses(responsesArr) {
+  if (!Array.isArray(responsesArr)) return [];
+  return responsesArr
+    .filter((r) => r && typeof r.answer === "string" && r.answer.trim() !== "")
+    .map((r) => ({ questionKey: r.questionKey, question: r.question, answer: r.answer }));
+}
+
+function buildBody(selectedCommitteeIds, responsesMap) {
+  const [first, second, third] = selectedCommitteeIds;
+  const firstResponses = first ? (responsesMap[first] || []) : [];
+  const secondResponses = second ? (responsesMap[second] || []) : [];
+  const thirdResponses = third ? (responsesMap[third] || []) : [];
+  return {
+    firstChoiceResponses: cleanResponses(firstResponses),
+    secondChoiceResponses: cleanResponses(secondResponses),
+    thirdChoiceResponses: cleanResponses(thirdResponses),
+  };
+}
+
+function slotKey(responsesArr) {
+  return cleanResponses(responsesArr)
+    .map((r) => `${r.questionKey}=${r.answer}`)
+    .sort()
+    .join("|");
+}
+
+function persistedMatchesCurrent(app, selectedCommitteeIds, responsesMap) {
+  const [first, second, third] = selectedCommitteeIds;
+  const current = [
+    slotKey(first ? (responsesMap[first] || []) : []),
+    slotKey(second ? (responsesMap[second] || []) : []),
+    slotKey(third ? (responsesMap[third] || []) : []),
+  ];
+  const persisted = [
+    slotKey(app.firstChoiceResponses || []),
+    slotKey(app.secondChoiceResponses || []),
+    slotKey(app.thirdChoiceResponses || []),
+  ];
+  return current.every((c, i) => c === persisted[i]);
+}
+
+export default function useStep2Save(selectedCommitteeIds) {
+  const [myApplication, setMyApplication] = useAtom(myApplicationAtom);
+  const [responsesByCommittee] = useAtom(responsesByCommitteeAtom);
+  const [saveState, setSaveState] = useState("idle");
+  const [error, setError] = useState(null);
+  const [errorKind, setErrorKind] = useState(null);
+
+  const timerRef = useRef(null);
+  const inFlightRef = useRef(null);
+  const latestIdsRef = useRef(selectedCommitteeIds);
+  const responsesMapRef = useRef(responsesByCommittee);
+  const appRef = useRef(myApplication);
+  const saveStateRef = useRef(saveState);
+  const errorRef = useRef(error);
+
+  useEffect(() => {
+    latestIdsRef.current = selectedCommitteeIds;
+  }, [selectedCommitteeIds]);
+
+  useEffect(() => {
+    responsesMapRef.current = responsesByCommittee;
+  }, [responsesByCommittee]);
+
+  useEffect(() => {
+    appRef.current = myApplication;
+  }, [myApplication]);
+
+  useEffect(() => {
+    saveStateRef.current = saveState;
+  }, [saveState]);
+
+  useEffect(() => {
+    errorRef.current = error;
+  }, [error]);
+
+  const doSave = useCallback(async () => {
+    const ids = latestIdsRef.current;
+    const map = responsesMapRef.current;
+    const app = appRef.current;
+
+    if (!app || !app._id) {
+      setSaveState("idle");
+      return;
+    }
+    if (!ids || ids.length === 0) {
+      setSaveState("idle");
+      return;
+    }
+
+    setSaveState("saving");
+    setError(null);
+    setErrorKind(null);
+
+    try {
+      const payload = buildBody(ids, map);
+      const result = await updateApplication(app._id, payload);
+      if (!result.success) {
+        if (result.notFound) {
+          setError("Application not found");
+          setErrorKind("notFound");
+        } else if (result.submittedBlock) {
+          setError("Application already submitted");
+          setErrorKind("submittedBlock");
+        } else {
+          setError(result.error || "Save failed");
+          setErrorKind("network");
+        }
+        setSaveState("error");
+        return;
+      }
+      setMyApplication(result.data);
+      appRef.current = result.data;
+      setSaveState("idle");
+      setErrorKind(null);
+    } catch (err) {
+      setError((err && err.message) || "Save failed");
+      setSaveState("error");
+      setErrorKind("network");
+    }
+  }, [setMyApplication]);
+
+  const runSave = useCallback(async () => {
+    if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+    const p = doSave();
+    inFlightRef.current = p;
+    try {
+      await p;
+    } finally {
+      if (inFlightRef.current === p) inFlightRef.current = null;
+    }
+  }, [doSave]);
+
+  useEffect(() => {
+    const app = appRef.current;
+    if (!app || !app._id) {
+      setSaveState("idle");
+      return undefined;
+    }
+    if (!selectedCommitteeIds || selectedCommitteeIds.length === 0) {
+      setSaveState("idle");
+      return undefined;
+    }
+    if (persistedMatchesCurrent(app, selectedCommitteeIds, responsesByCommittee)) {
+      setSaveState("idle");
+      return undefined;
+    }
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [responsesByCommittee, selectedCommitteeIds, runSave]);
+
+  const flushPending = useCallback(async () => {
+    if (!appRef.current || !appRef.current._id) return;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      await runSave();
+    } else if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+    if (saveStateRef.current === "error") {
+      throw new Error(errorRef.current || "Save failed");
+    }
+  }, [runSave]);
+
+  const retry = useCallback(() => {
+    setError(null);
+    setErrorKind(null);
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, 0);
+  }, [runSave]);
+
+  return { saveState, error, errorKind, flushPending, retry };
+}

--- a/components/Internship/ApplicationWizard/index.jsx
+++ b/components/Internship/ApplicationWizard/index.jsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai";
 
 import WizardProgressBar from "@/components/Internship/WizardProgressBar";
 import Step1Committees from "@/components/Internship/ApplicationWizard/Step1Committees";
+import Step2Questions from "@/components/Internship/ApplicationWizard/Step2Questions";
 import { myApplicationAtom } from "@/lib/atoms";
 
 const TOTAL_STEPS = 4;
@@ -13,10 +14,37 @@ export default function ApplicationWizard() {
   const draft = useAtomValue(myApplicationAtom);
   const [currentStep, setCurrentStep] = useState(1);
   const [step1Valid, setStep1Valid] = useState(false);
+  const [step2Valid, setStep2Valid] = useState(false);
   const [advancing, setAdvancing] = useState(false);
-  const flushPendingRef = useRef(null);
+  const flushPendingStep1Ref = useRef(null);
+  const flushPendingStep2Ref = useRef(null);
   const advancingRef = useRef(false);
   const handleStep1ValidityChange = useCallback((valid) => setStep1Valid(valid), []);
+  const handleStep2ValidityChange = useCallback((valid) => setStep2Valid(valid), []);
+
+  const nextDisabled =
+    currentStep === TOTAL_STEPS ||
+    (currentStep === 1 && !step1Valid) ||
+    (currentStep === 2 && !step2Valid) ||
+    advancing;
+
+  const handleNext = async () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
+    setAdvancing(true);
+    try {
+      if (currentStep === 1 && flushPendingStep1Ref.current) {
+        try { await flushPendingStep1Ref.current(); } catch { return; }
+      }
+      if (currentStep === 2 && flushPendingStep2Ref.current) {
+        try { await flushPendingStep2Ref.current(); } catch { return; }
+      }
+      setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
+    } finally {
+      advancingRef.current = false;
+      setAdvancing(false);
+    }
+  };
 
   return (
     <div className="mx-auto mt-[calc(61px+2rem)] max-w-3xl p-6">
@@ -31,16 +59,24 @@ export default function ApplicationWizard() {
         {currentStep === 1 && (
           <Step1Committees
             onValidityChange={handleStep1ValidityChange}
-            flushPendingRef={flushPendingRef}
+            flushPendingRef={flushPendingStep1Ref}
           />
         )}
-        {currentStep > 1 && <div className="text-slate-500">Step {currentStep} content (coming in a later phase)</div>}
+        {currentStep === 2 && (
+          <Step2Questions
+            onValidityChange={handleStep2ValidityChange}
+            flushPendingRef={flushPendingStep2Ref}
+          />
+        )}
+        {currentStep > 2 && (
+          <div className="text-slate-500">Step {currentStep} content (coming in a later phase)</div>
+        )}
       </div>
       <div className="mt-6 flex gap-2">
         <button
           type="button"
           className="rounded border border-gray-300 px-4 py-2 disabled:opacity-50"
-          onClick={() => setCurrentStep(s => Math.max(1, s - 1))}
+          onClick={() => setCurrentStep((s) => Math.max(1, s - 1))}
           disabled={currentStep === 1}
         >
           Back
@@ -48,25 +84,8 @@ export default function ApplicationWizard() {
         <button
           type="button"
           className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
-          onClick={async () => {
-            if (advancingRef.current) return;
-            advancingRef.current = true;
-            setAdvancing(true);
-            try {
-              if (currentStep === 1 && flushPendingRef.current) {
-                try {
-                  await flushPendingRef.current();
-                } catch {
-                  return;
-                }
-              }
-              setCurrentStep(s => Math.min(TOTAL_STEPS, s + 1));
-            } finally {
-              advancingRef.current = false;
-              setAdvancing(false);
-            }
-          }}
-          disabled={currentStep === TOTAL_STEPS || (currentStep === 1 && !step1Valid) || advancing}
+          onClick={handleNext}
+          disabled={nextDisabled}
         >
           Next
         </button>

--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -3,7 +3,7 @@
 import { atom } from "jotai";
 
 import type { UserExtendedProfile, UserPublicProfile } from "@/lib/types/User";
-import type { InternshipApplication, InternshipCommittee } from "@/lib/types/Internship";
+import type { InternshipApplication, InternshipCommittee, InternshipQuestionResponse } from "@/lib/types/Internship";
 
 export const authUserProfileAtom = atom<UserPublicProfile | UserExtendedProfile | null>(null);
 export const isAdminAtom = atom<boolean>(false);
@@ -13,3 +13,4 @@ export const officerViewAtom = atom<boolean>(false);
 export const myApplicationAtom = atom<InternshipApplication | null>(null);
 export const activeCommitteesAtom = atom<InternshipCommittee[] | null>(null);
 export const committeesAtom = atom<InternshipCommittee[]>([]);
+export const responsesByCommitteeAtom = atom<Record<string, InternshipQuestionResponse[]>>({});

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -28,6 +28,7 @@ export interface InternshipApplication {
   applicationCycle: string;
   submittedAt: string;
   lastModifiedAt: string;
+  submissionStatus?: "draft" | "submitted";
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Description

Implements Step 2 of the internship application wizard (dynamic per-committee questions) and completes the auto-save engine. Each selected committee gets a tab; members answer that committee's custom questions, and answers auto-save as a draft and re-hydrate on refresh.

Highlights:
- Tabbed question UI (`CommitteeTabBar`) — one tab per selected committee in rank order (1st / 2nd / 3rd), with a red dot on any tab that still has unanswered required questions
- `QuestionField` renders all three question types: `short_text`, `long_text` (with a live `N / 2000` character counter that caps at 2000), and `multiple_choice` (radio)
- Validation gating: required questions are marked with a red asterisk, and **Next** stays disabled until every selected committee's required questions are answered
- Auto-save engine: debounced 500ms save, a `Saving… → Saved [time]` indicator with retry on failure, and a concurrent-save guard so overlapping edits never race
- Answers are keyed by committee and follow the committee across reorder/unpick in Step 1, so they stay aligned with the backend's positional response slots

No backend changes are required — the existing application validator already accepts the per-committee response arrays.

## Related Issue

Resolves #322
Resolves #323

## Steps to view & test changes:

- Sign in with a completed profile as a general member (not admin/officer).
- A committee needs custom questions configured to exercise Step 2 — add some via the admin committee editor, otherwise you'll see the "This committee has no application questions." empty state.
- Go to `/internship/apply`, pick 2–3 committees in Step 1, then click **Next**.
- Verify a tab appears for each committee in rank order; switch between tabs.
- Verify required questions show a red asterisk, and the long-text field shows a live character counter that turns red and stops at 2000.
- Leave a required question blank — its tab shows a red dot and **Next** stays disabled. Fill it in — the dot clears and **Next** enables.
- As you type, the save indicator changes to `Saving…` then settles on `Saved [time]`.
- Go back to Step 1, reorder your committees, and return to Step 2 — your answers follow each committee rather than staying in the old position.
- Unpick a committee that had answers — its tab disappears in Step 2.
- Refresh the page — your answers re-hydrate from the saved draft.

## How Has This Been Tested?

- [x] Manual tests
- [x] Responsive View

## Screenshots (if appropriate)

_Add screenshots of Step 2: the committee tab bar (with a red incomplete dot) and a filled question form with the character counter._
