### PR TITLE
 Add application cycle management and committee archiving to internship dashboard

### DIFF
--- a/app/actions/internship/advanceApplicationCycle.ts
+++ b/app/actions/internship/advanceApplicationCycle.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { AdvanceCycleResult } from "@/lib/types/Internship";
+
+export default async function advanceApplicationCycle(newCycle: string): Promise<AdvanceCycleResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.cycleAdvance}`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ newCycle }),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`advanceApplicationCycle failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return {
+      success: true,
+      previousCycle: data.previousCycle,
+      newCycle: data.newCycle,
+      archivedCount: typeof data.archivedCount === "number" ? data.archivedCount : 0,
+    };
+  } catch (err) {
+    Logger.error(`advanceApplicationCycle failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to advance application cycle." };
+  }
+}

--- a/app/actions/internship/archiveCommittee.ts
+++ b/app/actions/internship/archiveCommittee.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { ArchiveCommitteeResult } from "@/lib/types/Internship";
+
+export default async function archiveCommittee(committeeId: string): Promise<ArchiveCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/archive`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`archiveCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return { success: true, archivedCount: typeof data?.archivedCount === "number" ? data.archivedCount : 0 };
+  } catch (err) {
+    Logger.error(`archiveCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to archive committee." };
+  }
+}

--- a/app/actions/internship/deleteCommittee.ts
+++ b/app/actions/internship/deleteCommittee.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { DeleteInternshipCommitteeResult } from "@/lib/types/Internship";
+
+export default async function deleteCommittee(committeeId: string): Promise<DeleteInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`deleteCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return { success: true };
+  } catch (err) {
+    Logger.error(`deleteCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to delete committee." };
+  }
+}

--- a/app/actions/internship/fetchAllApplications.ts
+++ b/app/actions/internship/fetchAllApplications.ts
@@ -5,13 +5,15 @@ import Config from "@/lib/config";
 import Logger from "@/lib/logger";
 import { isAuthenticated, isTokenAdmin, isTokenOfficer } from "@/lib/token";
 import type {
-  InternshipApplication,
-  InternshipApplicationsResult,
+  FetchApplicationsOptions,
+  InternshipApplicationsListResult,
 } from "@/lib/types/Internship";
 
-const APPLICATIONS_PAGE_LIMIT = 100;
+const DEFAULT_LIMIT = 25;
 
-export default async function fetchAllApplications(): Promise<InternshipApplicationsResult> {
+export default async function fetchAllApplications(
+  options: FetchApplicationsOptions = {},
+): Promise<InternshipApplicationsListResult> {
   try {
     const cks = await cookies();
     const token = cks.get("token")?.value;
@@ -24,7 +26,21 @@ export default async function fetchAllApplications(): Promise<InternshipApplicat
       return { success: false, error: "Not authorized" };
     }
 
-    const url = `${Config.API_URL}${Config.routes.internship.applications}?limit=${APPLICATIONS_PAGE_LIMIT}`;
+    const params = new URLSearchParams();
+    params.set("page", String(options.page ?? 1));
+    params.set("limit", String(options.limit ?? DEFAULT_LIMIT));
+    if (options.search) params.set("search", options.search);
+    // status/committeeId match "any of the application's 3 choice slots",
+    // not a specific slot — see the backend's getAllApplications for why
+    // this can't be done by setting firstChoiceStatus/etc. to the same value.
+    if (options.status) params.set("status", options.status);
+    if (options.committeeId) params.set("committeeId", options.committeeId);
+    if (options.choiceRank) params.set("choiceRank", options.choiceRank);
+    if (options.applicationCycle) params.set("applicationCycle", options.applicationCycle);
+    if (options.archived) params.set("archived", "true");
+    if (options.includeDrafts) params.set("includeDrafts", "true");
+
+    const url = `${Config.API_URL}${Config.routes.internship.applications}?${params.toString()}`;
     const response = await fetch(url, {
       headers: {
         Accept: "application/json",
@@ -42,8 +58,11 @@ export default async function fetchAllApplications(): Promise<InternshipApplicat
       return { success: false, error: message };
     }
 
-    const applications: InternshipApplication[] = data.data ?? [];
-    return { success: true, data: applications };
+    return {
+      success: true,
+      data: data.data ?? [],
+      pagination: data.pagination ?? { page: 1, limit: DEFAULT_LIMIT, total: 0, pages: 0 },
+    };
   } catch (err) {
     Logger.error(`fetchAllApplications failed: ${(err as Error).message}`);
     return { success: false, error: "Failed to fetch applications" };

--- a/app/actions/internship/fetchApplicationCycle.ts
+++ b/app/actions/internship/fetchApplicationCycle.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { FetchCycleInfoResult, InternshipCycleInfo } from "@/lib/types/Internship";
+
+export default async function fetchApplicationCycle(): Promise<FetchCycleInfoResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.cycle}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`fetchApplicationCycle failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const info: InternshipCycleInfo = {
+      currentCycle: data.currentCycle,
+      suggestedNextCycle: data.suggestedNextCycle,
+      pastCycles: Array.isArray(data.pastCycles) ? data.pastCycles : [],
+    };
+
+    return { success: true, data: info };
+  } catch (err) {
+    Logger.error(`fetchApplicationCycle failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application cycle." };
+  }
+}

--- a/app/actions/internship/fetchApplicationStatusCounts.ts
+++ b/app/actions/internship/fetchApplicationStatusCounts.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenAdmin, isTokenOfficer } from "@/lib/token";
+
+export type FetchApplicationStatusCountsResult =
+  | { success: true; counts: Record<string, number> }
+  | { success: false; error: string };
+
+export default async function fetchApplicationStatusCounts(
+  committeeId?: string,
+): Promise<FetchApplicationStatusCountsResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) {
+      return { success: false, error: "Not authenticated" };
+    }
+    if (!isTokenAdmin(token) && !isTokenOfficer(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const params = new URLSearchParams();
+    if (committeeId) params.set("committeeId", committeeId);
+
+    const url = `${Config.API_URL}${Config.routes.internship.applicationStatusCounts}?${params.toString()}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.success === false) {
+      const message = data?.message ?? data?.error ?? `Request failed (${response.status})`;
+      Logger.error(`fetchApplicationStatusCounts failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    return { success: true, counts: data.counts ?? {} };
+  } catch (err) {
+    Logger.error(`fetchApplicationStatusCounts failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application status counts" };
+  }
+}

--- a/app/actions/internship/submitApplication.ts
+++ b/app/actions/internship/submitApplication.ts
@@ -1,0 +1,71 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated } from "@/lib/token";
+import type { InternshipApplication } from "@/lib/types/Internship";
+
+type SubmitApplicationResult =
+  | { success: true; data: InternshipApplication }
+  | { success: false; error: string; notFound?: boolean; submittedBlock?: boolean };
+
+export default async function submitApplication(id: string): Promise<SubmitApplicationResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(
+      Config.API_URL + Config.routes.internship.applications + "/" + encodeURIComponent(id) + "/submit",
+      {
+        method: "POST",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (response.status === 404) {
+      return { success: false, error: "Application not found", notFound: true };
+    }
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.message ??
+        (typeof data?.error === "string" ? data.error : data?.error?.message) ??
+        `Failed to submit application (${response.status}).`;
+
+      const isSubmittedBlock =
+        (response.status === 400 || response.status === 403 || response.status === 409 || response.status === 422) &&
+        typeof msg === "string" &&
+        msg.toLowerCase().includes("submitted");
+
+      if (isSubmittedBlock) {
+        return { success: false, error: msg, submittedBlock: true };
+      }
+
+      return { success: false, error: msg };
+    }
+
+    const doc: InternshipApplication | undefined =
+      (data?.data as InternshipApplication | undefined) ??
+      (data?.application as InternshipApplication | undefined);
+
+    if (!doc) {
+      Logger.error("submitApplication failed: missing application in response");
+      return { success: false, error: "Failed to submit application." };
+    }
+
+    return { success: true, data: doc };
+  } catch (err) {
+    Logger.error(`submitApplication failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to submit application." };
+  }
+}

--- a/app/actions/internship/updateApplication.ts
+++ b/app/actions/internship/updateApplication.ts
@@ -17,6 +17,9 @@ export default async function updateApplication(
     firstChoiceCommittee?: string;
     secondChoiceCommittee?: string | null;
     thirdChoiceCommittee?: string | null;
+    phone?: string;
+    major?: string;
+    graduationYear?: number;
     firstChoiceResponses?: { questionKey: string; question: string; answer: string }[];
     secondChoiceResponses?: { questionKey: string; question: string; answer: string }[];
     thirdChoiceResponses?: { questionKey: string; question: string; answer: string }[];

--- a/app/actions/internship/updateApplication.ts
+++ b/app/actions/internship/updateApplication.ts
@@ -17,6 +17,11 @@ export default async function updateApplication(
     firstChoiceCommittee?: string;
     secondChoiceCommittee?: string | null;
     thirdChoiceCommittee?: string | null;
+    firstChoiceResponses?: { questionKey: string; question: string; answer: string }[];
+    secondChoiceResponses?: { questionKey: string; question: string; answer: string }[];
+    thirdChoiceResponses?: { questionKey: string; question: string; answer: string }[];
+    resumeUrl?: string;
+    coverLetter?: string;
   },
 ): Promise<UpdateApplicationResult> {
   try {

--- a/app/actions/internship/updateApplicationReview.ts
+++ b/app/actions/internship/updateApplicationReview.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated } from "@/lib/token";
+import type { InternshipApplication } from "@/lib/types/Internship";
+
+type UpdateApplicationReviewResult =
+  | { success: true; data: InternshipApplication }
+  | { success: false; error: string };
+
+export default async function updateApplicationReview(
+  id: string,
+  reviewField: string,
+  value: string | null,
+): Promise<UpdateApplicationReviewResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(
+      Config.API_URL + Config.routes.internship.applications + "/" + encodeURIComponent(id) + "/review",
+      {
+        method: "PUT",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ reviewField, value }),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.success === false) {
+      const validationMessage = Array.isArray(data?.errors) ? data.errors[0]?.msg : undefined;
+      const message =
+        validationMessage ?? data?.message ?? `Failed to update review (${response.status}).`;
+      Logger.error(`updateApplicationReview failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    const doc: InternshipApplication | undefined = data?.data;
+    if (!doc) {
+      Logger.error("updateApplicationReview failed: missing application in response");
+      return { success: false, error: "Failed to update review." };
+    }
+
+    return { success: true, data: doc };
+  } catch (err) {
+    Logger.error(`updateApplicationReview failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update review." };
+  }
+}

--- a/app/actions/internship/updateApplicationStatus.ts
+++ b/app/actions/internship/updateApplicationStatus.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated } from "@/lib/token";
+import type { InternshipApplication } from "@/lib/types/Internship";
+
+type StatusField = "firstChoiceStatus" | "secondChoiceStatus" | "thirdChoiceStatus";
+
+type UpdateApplicationStatusResult =
+  | { success: true; data: InternshipApplication }
+  | { success: false; error: string };
+
+export default async function updateApplicationStatus(
+  id: string,
+  statusField: StatusField,
+  status: string,
+): Promise<UpdateApplicationStatusResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) return { success: false, error: "Not authenticated" };
+
+    const response = await fetch(
+      Config.API_URL + Config.routes.internship.applications + "/" + encodeURIComponent(id) + "/status",
+      {
+        method: "PUT",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ statusField, status }),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.success === false) {
+      const validationMessage = Array.isArray(data?.errors) ? data.errors[0]?.msg : undefined;
+      const message =
+        validationMessage ?? data?.message ?? `Failed to update status (${response.status}).`;
+      Logger.error(`updateApplicationStatus failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    const doc: InternshipApplication | undefined = data?.data;
+    if (!doc) {
+      Logger.error("updateApplicationStatus failed: missing application in response");
+      return { success: false, error: "Failed to update status." };
+    }
+
+    return { success: true, data: doc };
+  } catch (err) {
+    Logger.error(`updateApplicationStatus failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update status." };
+  }
+}

--- a/app/actions/internship/updateCommittee.ts
+++ b/app/actions/internship/updateCommittee.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type {
+  UpdateInternshipCommitteePayload,
+  UpdateInternshipCommitteeResult,
+  InternshipCommittee,
+} from "@/lib/types/Internship";
+
+export default async function updateCommittee(
+  committeeId: string,
+  payload: UpdateInternshipCommitteePayload,
+): Promise<UpdateInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/admin`,
+      {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`updateCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const updated: InternshipCommittee | undefined = data?.committee;
+    if (!updated) {
+      Logger.error("updateCommittee failed: missing committee in response");
+      return { success: false, error: "Failed to update committee." };
+    }
+
+    return { success: true, data: updated };
+  } catch (err) {
+    Logger.error(`updateCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update committee." };
+  }
+}

--- a/app/actions/internship/updateCommitteeQuestions.ts
+++ b/app/actions/internship/updateCommitteeQuestions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin, isTokenOfficer } from "@/lib/token";
+import type {
+  InternshipCustomQuestion,
+  InternshipCommittee,
+  UpdateInternshipCommitteeResult,
+} from "@/lib/types/Internship";
+
+// Hits PUT /committees/:id/questions — the narrower endpoint officers can
+// use to edit their own committee's questions (backend scopes it via
+// canManageCommitteeResource), as opposed to /committees/:id/admin which
+// is admin-only and covers the full committee record.
+export default async function updateCommitteeQuestions(
+  committeeId: string,
+  customQuestions: InternshipCustomQuestion[],
+): Promise<UpdateInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token) && !isTokenOfficer(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/questions`,
+      {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ customQuestions }),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`updateCommitteeQuestions failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const updated: InternshipCommittee | undefined = data?.committee;
+    if (!updated) {
+      Logger.error("updateCommitteeQuestions failed: missing committee in response");
+      return { success: false, error: "Failed to update questions." };
+    }
+
+    return { success: true, data: updated };
+  } catch (err) {
+    Logger.error(`updateCommitteeQuestions failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update questions." };
+  }
+}

--- a/app/internship/admin/committees/[id]/edit/page.jsx
+++ b/app/internship/admin/committees/[id]/edit/page.jsx
@@ -1,15 +1,155 @@
 "use client";
 
-import { use } from "react";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import CommitteeForm from "@/components/Internship/CommitteeForm";
+import ConfirmationModal from "@/components/Modal/confirmationModal";
+import fetchCommitteeById from "@/app/actions/internship/fetchCommitteeById";
+import updateCommittee from "@/app/actions/internship/updateCommittee";
+import archiveCommittee from "@/app/actions/internship/archiveCommittee";
+import deleteCommittee from "@/app/actions/internship/deleteCommittee";
+import "@/components/Internship/AdminDashboard.scss";
 
 export default function EditCommitteePage({ params }) {
   const { id } = use(params);
+  const router = useRouter();
+
+  const [committee, setCommittee] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const [dangerError, setDangerError] = useState(null);
+  const [dangerPending, setDangerPending] = useState(false);
+  const [confirmAction, setConfirmAction] = useState(null); // "archive" | "delete" | null
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await fetchCommitteeById(id);
+      if (cancelled) return;
+      if (result.success) {
+        setCommittee(result.data);
+      } else {
+        setLoadError(result.error);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  async function handleSubmit(payload) {
+    const result = await updateCommittee(id, payload);
+    if (result.success) {
+      setCommittee(result.data);
+    }
+    return result;
+  }
+
+  async function handleConfirmDanger() {
+    const action = confirmAction;
+    setConfirmAction(null);
+    setDangerPending(true);
+    setDangerError(null);
+
+    if (action === "archive") {
+      const result = await archiveCommittee(id);
+      setDangerPending(false);
+      if (!result.success) {
+        setDangerError(result.error);
+        return;
+      }
+      window.alert(`Archived ${result.archivedCount} application${result.archivedCount === 1 ? "" : "s"} for this committee.`);
+      return;
+    }
+
+    if (action === "delete") {
+      const result = await deleteCommittee(id);
+      setDangerPending(false);
+      if (!result.success) {
+        setDangerError(result.error);
+        return;
+      }
+      router.push("/internship/admin");
+    }
+  }
+
   return (
     <ProtectedRoute requiredRole="admin">
-      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+      <div className="admin-dashboard">
         <h2>Edit Committee</h2>
-        <p>Committee editor coming soon. Editing committee: <code>{id}</code></p>
+
+        {loading && <div className="admin-dashboard__placeholder">Loading committee…</div>}
+        {!loading && loadError && (
+          <div className="committee-table-wrapper__error">{loadError}</div>
+        )}
+
+        {!loading && committee && (
+          <>
+            <CommitteeForm
+              initialValues={committee}
+              submitLabel="Save Changes"
+              onSubmit={handleSubmit}
+            />
+
+            <div className="committee-form__danger-zone">
+              <h3>Danger Zone</h3>
+              {dangerError && <div className="committee-form__error">{dangerError}</div>}
+              <div className="committee-form__danger-actions">
+                <div className="committee-form__danger-row">
+                  <div>
+                    <strong>Archive this committee&apos;s applications</strong>
+                    <p>
+                      Marks the committee&apos;s current-cycle applications as archived. They&apos;ll
+                      no longer appear in the current Applications view, but stay visible in the
+                      past-cycles view. The committee itself is unaffected.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="committee-form__danger-btn"
+                    disabled={dangerPending}
+                    onClick={() => setConfirmAction("archive")}
+                  >
+                    Archive Applications
+                  </button>
+                </div>
+
+                <div className="committee-form__danger-row">
+                  <div>
+                    <strong>Delete committee</strong>
+                    <p>
+                      Deactivates the committee (it stops accepting applications and disappears
+                      from active lists). This does not delete any existing application data.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="committee-form__danger-btn committee-form__danger-btn--delete"
+                    disabled={dangerPending}
+                    onClick={() => setConfirmAction("delete")}
+                  >
+                    Delete Committee
+                  </button>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        <ConfirmationModal
+          opened={confirmAction !== null}
+          title={confirmAction === "delete" ? "Delete this committee?" : "Archive this committee's applications?"}
+          message={
+            confirmAction === "delete"
+              ? "This deactivates the committee. It will stop accepting applications and disappear from active lists. This can be undone by reactivating it later."
+              : "This archives every current-cycle application for this committee. They'll be hidden from the current Applications view but remain visible in the past-cycles view."
+          }
+          submit={handleConfirmDanger}
+          cancel={() => setConfirmAction(null)}
+        />
       </div>
     </ProtectedRoute>
   );

--- a/app/internship/admin/committees/new/page.jsx
+++ b/app/internship/admin/committees/new/page.jsx
@@ -1,13 +1,27 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import CommitteeForm from "@/components/Internship/CommitteeForm";
+import createCommittee from "@/app/actions/internship/createCommittee";
+import "@/components/Internship/AdminDashboard.scss";
 
 export default function NewCommitteePage() {
+  const router = useRouter();
+
+  async function handleSubmit(payload) {
+    const result = await createCommittee(payload);
+    if (result.success) {
+      router.push("/internship/admin");
+    }
+    return result;
+  }
+
   return (
     <ProtectedRoute requiredRole="admin">
-      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+      <div className="admin-dashboard">
         <h2>Create Committee</h2>
-        <p>Committee editor coming soon.</p>
+        <CommitteeForm submitLabel="Create Committee" onSubmit={handleSubmit} />
       </div>
     </ProtectedRoute>
   );

--- a/app/internship/components/ApplicationDetailDrawer.jsx
+++ b/app/internship/components/ApplicationDetailDrawer.jsx
@@ -1,0 +1,95 @@
+"use client";
+
+import StatusUpdateDropdown from "./StatusUpdateDropdown";
+
+const CHOICE_RANK_LABELS = { 1: "1st Choice", 2: "2nd Choice", 3: "3rd Choice" };
+
+export default function ApplicationDetailDrawer({ application, onClose, onApplicationChanged }) {
+  if (!application) return null;
+
+  return (
+    <div className="application-detail-drawer__overlay" onClick={onClose}>
+      <div className="application-detail-drawer" onClick={(event) => event.stopPropagation()}>
+        <div className="application-detail-drawer__header">
+          <h3>{application.firstName} {application.lastName}</h3>
+          <button
+            type="button"
+            className="application-detail-drawer__close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        <section className="application-detail-drawer__section">
+          <h4>Candidate Profile</h4>
+          <dl className="application-detail-drawer__profile">
+            <div>
+              <dt>Email</dt>
+              <dd>{application.email}</dd>
+            </div>
+            {application.phone && (
+              <div>
+                <dt>Phone</dt>
+                <dd>{application.phone}</dd>
+              </div>
+            )}
+            <div>
+              <dt>University</dt>
+              <dd>{application.university}</dd>
+            </div>
+            <div>
+              <dt>Major</dt>
+              <dd>{application.major}</dd>
+            </div>
+            <div>
+              <dt>Graduation Year</dt>
+              <dd>{application.graduationYear ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Resume</dt>
+              <dd>
+                {application.resumeUrl ? (
+                  <a href={application.resumeUrl} target="_blank" rel="noopener noreferrer">
+                    View resume
+                  </a>
+                ) : (
+                  "—"
+                )}
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="application-detail-drawer__section">
+          <div className="application-detail-drawer__status-row">
+            <h4>{CHOICE_RANK_LABELS[application.myChoiceRank] ?? "Status"}</h4>
+            <StatusUpdateDropdown
+              applicationId={application._id}
+              statusField={application.myStatusField}
+              status={application.myStatus}
+              onChanged={onApplicationChanged}
+            />
+          </div>
+        </section>
+
+        <section className="application-detail-drawer__section">
+          <h4>Committee Responses</h4>
+          {application.myResponses.length === 0 ? (
+            <p className="application-detail-drawer__empty">No responses submitted.</p>
+          ) : (
+            <dl className="application-detail-drawer__responses">
+              {application.myResponses.map((response) => (
+                <div key={response.questionKey}>
+                  <dt>{response.question}</dt>
+                  <dd>{response.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/internship/components/ApplicationTable.jsx
+++ b/app/internship/components/ApplicationTable.jsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { memo } from "react";
+
+import NotesCell from "./NotesCell";
+import RatingDropdown from "./RatingDropdown";
+import StatusUpdateDropdown from "./StatusUpdateDropdown";
+
+const CHOICE_RANK_LABELS = { 1: "1st Choice", 2: "2nd Choice", 3: "3rd Choice" };
+
+function ApplicationRow({ application, onApplicationChanged, onRowClick }) {
+  return (
+    <tr className="officer-application-table__row" onClick={() => onRowClick(application._id)}>
+      <td>{application.firstName} {application.lastName}</td>
+      <td className="officer-application-table__email-col">{application.email}</td>
+      <td>{application.graduationYear ?? "—"}</td>
+      <td>{application.major}</td>
+      <td>{CHOICE_RANK_LABELS[application.myChoiceRank] ?? "—"}</td>
+      <td onClick={(event) => event.stopPropagation()}>
+        <StatusUpdateDropdown
+          applicationId={application._id}
+          statusField={application.myStatusField}
+          status={application.myStatus}
+          onChanged={onApplicationChanged}
+        />
+      </td>
+      <td onClick={(event) => event.stopPropagation()}>
+        <RatingDropdown
+          applicationId={application._id}
+          reviewField={application.myOfficer1RatingField}
+          value={application.myOfficer1Rating}
+          onChanged={onApplicationChanged}
+        />
+      </td>
+      <td onClick={(event) => event.stopPropagation()}>
+        <RatingDropdown
+          applicationId={application._id}
+          reviewField={application.myOfficer2RatingField}
+          value={application.myOfficer2Rating}
+          onChanged={onApplicationChanged}
+        />
+      </td>
+      <td className="officer-application-table__notes-col" onClick={(event) => event.stopPropagation()}>
+        <NotesCell
+          applicationId={application._id}
+          reviewField={application.myNotesField}
+          value={application.myNotes}
+          onChanged={onApplicationChanged}
+        />
+      </td>
+    </tr>
+  );
+}
+
+const MemoApplicationRow = memo(ApplicationRow);
+
+export default function ApplicationTable({ applications, onApplicationChanged, onRowClick }) {
+  if (applications.length === 0) {
+    return (
+      <div className="officer-application-table__empty">
+        No applications match the current filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="officer-application-table__scroll">
+      <table className="officer-application-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Year</th>
+            <th>Major</th>
+            <th>Choice Rank</th>
+            <th>Status</th>
+            <th>Officer 1</th>
+            <th>Officer 2</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {applications.map((application) => (
+            <MemoApplicationRow
+              key={application._id}
+              application={application}
+              onApplicationChanged={onApplicationChanged}
+              onRowClick={onRowClick}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/internship/components/CopyEmailsButton.jsx
+++ b/app/internship/components/CopyEmailsButton.jsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+
+export default function CopyEmailsButton({ applications, onCopied, onError }) {
+  const [copying, setCopying] = useState(false);
+
+  const handleClick = async () => {
+    const emails = applications.map((application) => application.email).filter(Boolean);
+    if (emails.length === 0) return;
+
+    setCopying(true);
+    try {
+      await navigator.clipboard.writeText(emails.join(", "));
+      onCopied(emails.length);
+    } catch (err) {
+      onError((err && err.message) || "Couldn't copy emails to clipboard");
+    } finally {
+      setCopying(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="copy-emails-button"
+      onClick={handleClick}
+      disabled={copying || applications.length === 0}
+    >
+      Copy Emails ({applications.length})
+    </button>
+  );
+}

--- a/app/internship/components/CopyEmailsButton.jsx
+++ b/app/internship/components/CopyEmailsButton.jsx
@@ -2,15 +2,21 @@
 
 import { useState } from "react";
 
-export default function CopyEmailsButton({ applications, onCopied, onError }) {
+// `onFetchAllEmails` (not a static `applications` array) because the
+// underlying application list is now server-paginated — "copy all matching
+// emails" has to walk every page under the current filters, not just
+// whichever page happens to be on screen.
+export default function CopyEmailsButton({ totalCount, onFetchAllEmails, onCopied, onError }) {
   const [copying, setCopying] = useState(false);
 
   const handleClick = async () => {
-    const emails = applications.map((application) => application.email).filter(Boolean);
-    if (emails.length === 0) return;
-
     setCopying(true);
     try {
+      const emails = await onFetchAllEmails();
+      if (emails.length === 0) {
+        setCopying(false);
+        return;
+      }
       await navigator.clipboard.writeText(emails.join(", "));
       onCopied(emails.length);
     } catch (err) {
@@ -25,9 +31,9 @@ export default function CopyEmailsButton({ applications, onCopied, onError }) {
       type="button"
       className="copy-emails-button"
       onClick={handleClick}
-      disabled={copying || applications.length === 0}
+      disabled={copying || totalCount === 0}
     >
-      Copy Emails ({applications.length})
+      {copying ? "Copying…" : `Copy Emails (${totalCount})`}
     </button>
   );
 }

--- a/app/internship/components/NotesCell.jsx
+++ b/app/internship/components/NotesCell.jsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { memo, useEffect, useRef, useState } from "react";
+
+import updateApplicationReview from "@/app/actions/internship/updateApplicationReview";
+
+const TRUNCATE_LENGTH = 60;
+
+function NotesCell({ applicationId, reviewField, value, onChanged }) {
+  const savedValue = value || "";
+  const isLong = savedValue.length > TRUNCATE_LENGTH;
+
+  const [expanded, setExpanded] = useState(false);
+  const [draft, setDraft] = useState(savedValue);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const textareaRef = useRef(null);
+
+  useEffect(() => {
+    setDraft(savedValue);
+  }, [savedValue]);
+
+  // Grow the textarea to fit its full content instead of leaving a fixed
+  // row count that clips long notes behind an internal scrollbar.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  });
+
+  const handleBlur = async () => {
+    const trimmed = draft.trim();
+    if (trimmed === savedValue) return;
+
+    setSaving(true);
+    setError(null);
+
+    const result = await updateApplicationReview(applicationId, reviewField, trimmed);
+
+    setSaving(false);
+
+    if (!result.success) {
+      setError(result.error || "Save failed");
+      return;
+    }
+
+    onChanged(applicationId, result.data);
+  };
+
+  // Long, unedited notes collapse to a preview with a "Read more" toggle;
+  // short notes (or once expanded) show a directly-editable textarea.
+  if (isLong && !expanded) {
+    return (
+      <div className="notes-cell">
+        <p className="notes-cell__preview">{savedValue.slice(0, TRUNCATE_LENGTH)}…</p>
+        <button type="button" className="notes-cell__toggle" onClick={() => setExpanded(true)}>
+          Read more
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="notes-cell">
+      <textarea
+        ref={textareaRef}
+        className="notes-cell__textarea"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={handleBlur}
+        disabled={saving}
+        rows={2}
+        placeholder="Add a note…"
+      />
+      {isLong && (
+        <button type="button" className="notes-cell__toggle" onClick={() => setExpanded(false)}>
+          Show less
+        </button>
+      )}
+      {error && <span className="notes-cell__error">{error}</span>}
+    </div>
+  );
+}
+
+export default memo(NotesCell);

--- a/app/internship/components/OfficerFilterBar.jsx
+++ b/app/internship/components/OfficerFilterBar.jsx
@@ -1,0 +1,61 @@
+"use client";
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "All statuses" },
+  { value: "pending", label: "Pending" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "interview_scheduled", label: "Interview Scheduled" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+];
+
+const CHOICE_OPTIONS = [
+  { value: "all", label: "All choices" },
+  { value: "1", label: "1st Choice" },
+  { value: "2", label: "2nd Choice" },
+  { value: "3", label: "3rd Choice" },
+];
+
+export default function OfficerFilterBar({
+  statusFilter,
+  onStatusFilterChange,
+  choiceFilter,
+  onChoiceFilterChange,
+  searchInput,
+  onSearchInputChange,
+}) {
+  return (
+    <div className="officer-filter-bar">
+      <input
+        type="search"
+        className="officer-filter-bar__search"
+        placeholder="Search by name or email"
+        value={searchInput}
+        onChange={(event) => onSearchInputChange(event.target.value)}
+        aria-label="Search applications by name or email"
+      />
+
+      <label className="officer-filter-bar__field">
+        <span className="officer-filter-bar__label">Status</span>
+        <select value={statusFilter} onChange={(event) => onStatusFilterChange(event.target.value)}>
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="officer-filter-bar__field">
+        <span className="officer-filter-bar__label">Choice</span>
+        <select value={choiceFilter} onChange={(event) => onChoiceFilterChange(event.target.value)}>
+          {CHOICE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/app/internship/components/OfficerStatsBar.jsx
+++ b/app/internship/components/OfficerStatsBar.jsx
@@ -1,0 +1,33 @@
+"use client";
+
+const STATUS_PILLS = [
+  { value: "pending", label: "Pending" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "interview_scheduled", label: "Interview Scheduled" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+];
+
+export default function OfficerStatsBar({ counts, activeStatus, onSelectStatus }) {
+  return (
+    <div className="officer-stats-bar" role="group" aria-label="Filter by status">
+      {STATUS_PILLS.map((pill) => {
+        const isActive = activeStatus === pill.value;
+        return (
+          <button
+            key={pill.value}
+            type="button"
+            className={`officer-stats-bar__pill officer-stats-bar__pill--${pill.value}${
+              isActive ? " officer-stats-bar__pill--active" : ""
+            }`}
+            onClick={() => onSelectStatus(isActive ? "all" : pill.value)}
+            aria-pressed={isActive}
+          >
+            <span className="officer-stats-bar__count">{counts[pill.value] ?? 0}</span>
+            <span className="officer-stats-bar__label">{pill.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/internship/components/RatingDropdown.jsx
+++ b/app/internship/components/RatingDropdown.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { memo, useState } from "react";
+
+import updateApplicationReview from "@/app/actions/internship/updateApplicationReview";
+
+const RATING_OPTIONS = [
+  { value: "", label: "Not rated" },
+  { value: "yes", label: "Yes" },
+  { value: "no", label: "No" },
+  { value: "maybe", label: "Maybe" },
+];
+
+function RatingDropdown({ applicationId, reviewField, value, onChanged }) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleChange = async (event) => {
+    const nextValue = event.target.value || null;
+
+    setSaving(true);
+    setError(null);
+
+    const result = await updateApplicationReview(applicationId, reviewField, nextValue);
+
+    setSaving(false);
+
+    if (!result.success) {
+      setError(result.error || "Update failed");
+      return;
+    }
+
+    onChanged(applicationId, result.data);
+  };
+
+  const currentLabel = RATING_OPTIONS.find((option) => option.value === (value || ""))?.label ?? "";
+
+  return (
+    <div className="rating-dropdown">
+      <select
+        className={`rating-dropdown__select rating-dropdown__select--${value || "unrated"}`}
+        value={value || ""}
+        onChange={handleChange}
+        disabled={saving}
+        aria-label="Update rating"
+        title={currentLabel}
+      >
+        {RATING_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {error && <span className="rating-dropdown__error">{error}</span>}
+    </div>
+  );
+}
+
+export default memo(RatingDropdown);

--- a/app/internship/components/StatusUpdateDropdown.jsx
+++ b/app/internship/components/StatusUpdateDropdown.jsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { memo, useState } from "react";
+
+import updateApplicationStatus from "@/app/actions/internship/updateApplicationStatus";
+
+const STATUS_OPTIONS = [
+  { value: "pending", label: "Pending" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "interview_scheduled", label: "Interview Scheduled" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+];
+
+function StatusUpdateDropdown({ applicationId, statusField, status, onChanged }) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleChange = async (event) => {
+    const nextStatus = event.target.value;
+    setSaving(true);
+    setError(null);
+
+    const result = await updateApplicationStatus(applicationId, statusField, nextStatus);
+
+    setSaving(false);
+
+    if (!result.success) {
+      setError(result.error || "Update failed");
+      return;
+    }
+
+    onChanged(applicationId, result.data);
+  };
+
+  const currentLabel = STATUS_OPTIONS.find((option) => option.value === status)?.label ?? "";
+
+  return (
+    <div className="status-update-dropdown">
+      <select
+        className={`status-update-dropdown__select status-update-dropdown__select--${status}`}
+        value={status}
+        onChange={handleChange}
+        disabled={saving}
+        aria-label="Update application status"
+        title={currentLabel}
+      >
+        {STATUS_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {error && <span className="status-update-dropdown__error">{error}</span>}
+    </div>
+  );
+}
+
+export default memo(StatusUpdateDropdown);

--- a/app/profile/career/page.jsx
+++ b/app/profile/career/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import Topbar from "@/components/Topbar";
 import CareerLanding from "../CareerLanding";
@@ -17,6 +17,7 @@ export default function CareerPage() {
   const activeCommittees = useAtomValue(activeCommitteesAtom);
   const setActiveCommittees = useSetAtom(activeCommitteesAtom);
   const [mounted, setMounted] = useState(false);
+  const hasRequestedCommitteesRef = useRef(false);
   const [careerProfile, setCareerProfile] = useState(userProfile || {});
 
   useEffect(() => {
@@ -35,7 +36,13 @@ export default function CareerPage() {
     })();
   }, [userProfile]);
 
+  // Guarded to run once per mount — without hasRequestedCommitteesRef, this
+  // would loop forever: setActiveCommittees below always produces a new
+  // array, which re-triggers this effect since activeCommittees is a dep.
   useEffect(() => {
+    if (hasRequestedCommitteesRef.current) return;
+    hasRequestedCommitteesRef.current = true;
+
     fetchAllCommittees().then(result => {
       if (result.success) {
         setActiveCommittees(result.data.filter(c => c.isActive));
@@ -43,7 +50,7 @@ export default function CareerPage() {
         setActiveCommittees([]);
       }
     });
-  }, [activeCommittees, setActiveCommittees]);
+  }, [setActiveCommittees]);
 
   const handleLogout = async () => {
     await logoutUser();

--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import CommitteeTable from "@/components/Internship/CommitteeTable";
 import ApplicationTable from "@/components/Internship/ApplicationTable";
 import fetchCommittees from "@/app/actions/internship/fetchCommittees";
-import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
 import "./AdminDashboard.scss";
 
 const TABS = [
@@ -17,9 +16,6 @@ export default function AdminDashboard() {
   const [committees, setCommittees] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [applications, setApplications] = useState([]);
-  const [applicationsStatus, setApplicationsStatus] = useState("idle");
-  const [applicationsError, setApplicationsError] = useState(null);
 
   const loadCommittees = useCallback(async () => {
     setLoading(true);
@@ -33,28 +29,9 @@ export default function AdminDashboard() {
     setLoading(false);
   }, []);
 
-  const loadApplications = useCallback(async () => {
-    setApplicationsStatus("loading");
-    const result = await fetchAllApplications();
-    if (result.success) {
-      setApplications(result.data);
-      setApplicationsError(null);
-      setApplicationsStatus("success");
-    } else {
-      setApplicationsError(result.error);
-      setApplicationsStatus("error");
-    }
-  }, []);
-
   useEffect(() => {
     Promise.resolve().then(loadCommittees);
   }, [loadCommittees]);
-
-  useEffect(() => {
-    if (activeTab === "applications" && applicationsStatus === "idle") {
-      Promise.resolve().then(loadApplications);
-    }
-  }, [activeTab, applicationsStatus, loadApplications]);
 
   return (
     <div className="admin-dashboard">
@@ -88,27 +65,7 @@ export default function AdminDashboard() {
             )}
           </>
         )}
-        {activeTab === "applications" && (
-          <>
-            {applicationsStatus === "loading" && (
-              <div className="admin-dashboard__placeholder">Loading applications…</div>
-            )}
-            {applicationsStatus === "error" && (
-              <div className="committee-table-wrapper__error">
-                {applicationsError}
-                <button
-                  type="button"
-                  onClick={() => setApplicationsStatus("idle")}
-                >
-                  Retry
-                </button>
-              </div>
-            )}
-            {applicationsStatus === "success" && (
-              <ApplicationTable applications={applications} committees={committees} />
-            )}
-          </>
-        )}
+        {activeTab === "applications" && <ApplicationTable committees={committees} />}
       </div>
     </div>
   );

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -82,6 +82,16 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    &--warning {
+      color: vars.$dark-red;
+      border-color: vars.$dark-red;
+
+      &:hover:not(:disabled) {
+        background: vars.$dark-red;
+        color: vars.$white;
+      }
+    }
   }
 
   &__error {
@@ -152,6 +162,95 @@
       text-decoration: underline;
     }
   }
+
+  &__row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__delete-link {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    color: vars.$dark-red;
+    font-weight: 500;
+    font-size: inherit;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      text-decoration: underline;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.cycle-controls {
+  position: relative;
+
+  &__panel {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    z-index: 10;
+    width: 320px;
+    background: vars.$white;
+    border: 1px solid vars.$gray1;
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__loading {
+    color: vars.$gray3;
+    font-size: 0.85rem;
+  }
+
+  &__current {
+    font-size: 0.9rem;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+
+    input {
+      padding: 0.4rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.9rem;
+    }
+  }
+
+  &__warning {
+    font-size: 0.78rem;
+    color: vars.$gray3;
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__notice {
+    background: rgba(52, 220, 106, 0.12);
+    color: vars.$dark-green;
+    padding: 0.65rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+  }
 }
 
 .application-table-wrapper {
@@ -173,6 +272,36 @@
     padding: 2rem;
     text-align: center;
     color: vars.$gray3;
+  }
+
+  &__pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: vars.$gray3;
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      padding: 0.4rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+
+      &:hover:not(:disabled) {
+        border-color: vars.$primary-color;
+        color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
   }
 }
 
@@ -272,6 +401,156 @@
     font-size: 0.7rem;
     font-weight: 600;
     text-align: center;
+  }
+}
+
+.committee-form {
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1rem;
+
+  &__error {
+    background: rgba(247, 78, 78, 0.1);
+    color: vars.$dark-red;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+
+    input[type="text"],
+    input[type="number"],
+    input[type="date"],
+    textarea {
+      padding: 0.5rem 0.75rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      font-family: inherit;
+
+      &:focus {
+        outline: none;
+        border-color: vars.$primary-color;
+      }
+    }
+
+    &--inline {
+      max-width: 260px;
+    }
+
+    &--checkbox {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
+    }
+  }
+
+  &__label {
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
+  &__hint {
+    font-size: 0.78rem;
+    color: vars.$gray3;
+  }
+
+  &__actions {
+    margin-top: 0.5rem;
+  }
+
+  &__submit {
+    appearance: none;
+    background: vars.$primary-color;
+    color: vars.$white;
+    border: none;
+    padding: 0.6rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+
+    &:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__danger-zone {
+    max-width: 700px;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid vars.$gray1;
+
+    h3 {
+      color: vars.$dark-red;
+      font-size: 1rem;
+      margin-bottom: 1rem;
+    }
+  }
+
+  &__danger-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__danger-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem;
+    border: 1px solid rgba(247, 78, 78, 0.3);
+    border-radius: 6px;
+
+    p {
+      margin: 0.25rem 0 0;
+      font-size: 0.82rem;
+      color: vars.$gray3;
+    }
+  }
+
+  &__danger-btn {
+    appearance: none;
+    flex-shrink: 0;
+    background: vars.$white;
+    color: vars.$dark-red;
+    border: 1px solid vars.$dark-red;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+      background: vars.$dark-red;
+      color: vars.$white;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &--delete {
+      background: vars.$dark-red;
+      color: vars.$white;
+
+      &:hover:not(:disabled) {
+        opacity: 0.85;
+      }
+    }
   }
 }
 

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -460,6 +460,180 @@
     color: vars.$gray3;
   }
 
+  &__questions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__question-add {
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$primary-color;
+    color: vars.$primary-color;
+    border-radius: 4px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-size: 0.82rem;
+
+    &:hover {
+      background: vars.$primary-color;
+      color: vars.$white;
+    }
+  }
+
+  &__question {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 6px;
+  }
+
+  &__question-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    button {
+      appearance: none;
+      background: none;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      cursor: pointer;
+      padding: 0.3rem 0.5rem;
+      font-size: 0.8rem;
+      color: vars.$gray3;
+
+      &:hover:not(:disabled) {
+        color: vars.$primary-color;
+        border-color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+    }
+
+    &--meta {
+      flex-wrap: wrap;
+    }
+  }
+
+  &__question-index {
+    font-size: 0.82rem;
+    color: vars.$gray3;
+    min-width: 1.25rem;
+  }
+
+  &__question-text {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  &__question-remove {
+    color: vars.$dark-red !important;
+    border-color: vars.$dark-red !important;
+  }
+
+  &__question-key,
+  &__question-type {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.78rem;
+    color: vars.$gray3;
+
+    input,
+    select {
+      padding: 0.35rem 0.5rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.82rem;
+      font-family: inherit;
+    }
+  }
+
+  &__question-required {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    align-self: flex-end;
+  }
+
+  &__choices {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__choice-input {
+    display: flex;
+    gap: 0.5rem;
+
+    input {
+      flex: 1;
+      padding: 0.4rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.85rem;
+    }
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$primary-color;
+      color: vars.$primary-color;
+      border-radius: 4px;
+      padding: 0.35rem 0.8rem;
+      cursor: pointer;
+      font-size: 0.82rem;
+
+      &:hover {
+        background: vars.$primary-color;
+        color: vars.$white;
+      }
+    }
+  }
+
+  &__choice-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__choice-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 999px;
+    padding: 0.2rem 0.4rem 0.2rem 0.75rem;
+    font-size: 0.82rem;
+
+    button {
+      appearance: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 1rem;
+      line-height: 1;
+      color: vars.$gray3;
+      padding: 0.1rem 0.3rem;
+
+      &:hover {
+        color: vars.$dark-red;
+      }
+    }
+  }
+
   &__actions {
     margin-top: 0.5rem;
   }

--- a/components/Internship/ApplicationStatusCard.jsx
+++ b/components/Internship/ApplicationStatusCard.jsx
@@ -18,6 +18,12 @@ export default function ApplicationStatusCard() {
   const myApplication = useAtomValue(myApplicationAtom);
   const activeCommittees = useAtomValue(activeCommitteesAtom);
 
+  const applicationWizardLink = (
+    <Link href="/internship/apply" className="application-status-card__button">
+      Start/Continue application
+    </Link>
+  );
+
   // Branch 0: Loading
   if (activeCommittees === null) {
     return (
@@ -42,9 +48,7 @@ export default function ApplicationStatusCard() {
             Applications are open
           </div>
           <div className="application-status-card__cta">
-            <Link href="/internship/apply" className="application-status-card__button">
-              Start Application
-            </Link>
+            {applicationWizardLink}
           </div>
         </div>
       </div>
@@ -67,9 +71,7 @@ export default function ApplicationStatusCard() {
             {thirdName && <span className="committee-chip">{thirdName}</span>}
           </div>
           <div className="application-status-card__cta">
-            <Link href="/internship/apply" className="application-status-card__button">
-              Continue Application
-            </Link>
+            {applicationWizardLink}
           </div>
           {myApplication.lastModifiedAt && (
             <p className="application-status-card__timestamp">

--- a/components/Internship/ApplicationStatusCard.jsx
+++ b/components/Internship/ApplicationStatusCard.jsx
@@ -56,7 +56,7 @@ export default function ApplicationStatusCard() {
   }
 
   // Branch 2: Draft
-  if (myApplication && !myApplication.submittedAt) {
+  if (myApplication && myApplication.submissionStatus !== "submitted") {
     const firstName = getCommitteeName(committees, myApplication.firstChoiceCommittee);
     const secondName = getCommitteeName(committees, myApplication.secondChoiceCommittee);
     const thirdName = getCommitteeName(committees, myApplication.thirdChoiceCommittee);
@@ -84,7 +84,7 @@ export default function ApplicationStatusCard() {
   }
 
   // Branch 3: Submitted
-  if (myApplication && myApplication.submittedAt) {
+  if (myApplication && myApplication.submissionStatus === "submitted") {
     const choices = [
       {
         committeeId: myApplication.firstChoiceCommittee,

--- a/components/Internship/ApplicationStatusCard.jsx
+++ b/components/Internship/ApplicationStatusCard.jsx
@@ -3,20 +3,23 @@
 import { useAtomValue } from "jotai";
 import Link from "next/link";
 import { myApplicationAtom, activeCommitteesAtom } from "@/lib/atoms";
+import useResolvedCommitteeNames, { getCommitteeDisplayName } from "@/lib/hooks/useResolvedCommitteeNames";
 import ApplicationStatusBadge from "./ApplicationStatusBadge";
 import "./style.scss";
-
-function getCommitteeName(committees, committeeId) {
-  if (!committeeId) return null;
-  const committee = committees.find(
-    (c) => c.id === committeeId || String(c._id) === committeeId,
-  );
-  return committee?.displayName ?? committeeId;
-}
 
 export default function ApplicationStatusCard() {
   const myApplication = useAtomValue(myApplicationAtom);
   const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const committees = activeCommittees ?? [];
+
+  const applicationCommitteeIds = myApplication
+    ? [
+        myApplication.firstChoiceCommittee,
+        myApplication.secondChoiceCommittee,
+        myApplication.thirdChoiceCommittee,
+      ].filter(Boolean)
+    : [];
+  const resolvedNames = useResolvedCommitteeNames(applicationCommitteeIds, committees);
 
   const applicationWizardLink = (
     <Link href="/internship/apply" className="application-status-card__button">
@@ -35,8 +38,6 @@ export default function ApplicationStatusCard() {
       </div>
     );
   }
-
-  const committees = activeCommittees ?? [];
 
   // Branch 1: Open, no application
   if (!myApplication && committees.length > 0) {
@@ -57,9 +58,9 @@ export default function ApplicationStatusCard() {
 
   // Branch 2: Draft
   if (myApplication && myApplication.submissionStatus !== "submitted") {
-    const firstName = getCommitteeName(committees, myApplication.firstChoiceCommittee);
-    const secondName = getCommitteeName(committees, myApplication.secondChoiceCommittee);
-    const thirdName = getCommitteeName(committees, myApplication.thirdChoiceCommittee);
+    const firstName = getCommitteeDisplayName(committees, resolvedNames, myApplication.firstChoiceCommittee);
+    const secondName = getCommitteeDisplayName(committees, resolvedNames, myApplication.secondChoiceCommittee);
+    const thirdName = getCommitteeDisplayName(committees, resolvedNames, myApplication.thirdChoiceCommittee);
 
     return (
       <div className="application-status-card">
@@ -114,7 +115,7 @@ export default function ApplicationStatusCard() {
               <ApplicationStatusBadge
                 key={index}
                 status={choice.status}
-                committeeName={getCommitteeName(committees, choice.committeeId)}
+                committeeName={getCommitteeDisplayName(committees, resolvedNames, choice.committeeId)}
               />
             ))}
           </div>

--- a/components/Internship/ApplicationTable.jsx
+++ b/components/Internship/ApplicationTable.jsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
+import fetchApplicationCycle from "@/app/actions/internship/fetchApplicationCycle";
+import useDebouncedValue from "@/lib/hooks/useDebouncedValue";
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "All statuses" },
+  { value: "pending", label: "Pending" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "interview_scheduled", label: "Interview Scheduled" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+];
+
+const PAGE_SIZE = 25;
 
 function formatDate(value) {
   if (!value) return "—";
@@ -13,26 +27,32 @@ function formatDate(value) {
   });
 }
 
-function applicationStatuses(application) {
-  return [
-    application.firstChoiceStatus,
-    application.secondChoiceStatus,
-    application.thirdChoiceStatus,
-  ].filter(Boolean);
+// Resolves a cycleFilter selection into the {applicationCycle, archived}
+// params fetchAllApplications expects. "current" intentionally omits both —
+// the backend already defaults to non-archived applications.
+function resolveCycleParams(cycleFilter) {
+  if (cycleFilter === "current") return {};
+  if (cycleFilter === "archived") return { archived: true };
+  if (cycleFilter.startsWith("archived:")) {
+    return { archived: true, applicationCycle: cycleFilter.slice("archived:".length) };
+  }
+  return {};
 }
 
-function applicationCommittees(application) {
-  return [
-    application.firstChoiceCommittee,
-    application.secondChoiceCommittee,
-    application.thirdChoiceCommittee,
-  ].filter(Boolean);
-}
-
-export default function ApplicationTable({ applications = [], committees = [] }) {
+export default function ApplicationTable({ committees = [] }) {
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
   const [statusFilter, setStatusFilter] = useState("all");
   const [committeeFilter, setCommitteeFilter] = useState("all");
+  const [cycleFilter, setCycleFilter] = useState("current");
+  const [page, setPage] = useState(1);
+
+  const [cycleInfo, setCycleInfo] = useState(null);
+
+  const [applications, setApplications] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, limit: PAGE_SIZE, total: 0, pages: 0 });
+  const [status, setStatus] = useState("loading"); // loading | success | error
+  const [error, setError] = useState(null);
 
   const committeeLookup = useMemo(() => {
     const map = new Map();
@@ -40,40 +60,51 @@ export default function ApplicationTable({ applications = [], committees = [] })
     return map;
   }, [committees]);
 
-  const statusOptions = useMemo(() => {
-    const set = new Set();
-    applications.forEach(app => {
-      applicationStatuses(app).forEach(s => set.add(s));
-    });
-    return Array.from(set).sort();
-  }, [applications]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await fetchApplicationCycle();
+      if (!cancelled && result.success) setCycleInfo(result.data);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  const filtered = useMemo(() => {
-    const term = search.trim().toLowerCase();
-    return applications.filter(app => {
-      if (term) {
-        const haystack = `${app.firstName ?? ""} ${app.lastName ?? ""} ${app.email ?? ""}`.toLowerCase();
-        if (!haystack.includes(term)) return false;
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setStatus("loading");
+      const result = await fetchAllApplications({
+        page,
+        limit: PAGE_SIZE,
+        search: debouncedSearch.trim() || undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+        committeeId: committeeFilter !== "all" ? committeeFilter : undefined,
+        ...resolveCycleParams(cycleFilter),
+      });
+      if (cancelled) return;
+      if (result.success) {
+        setApplications(result.data);
+        setPagination(result.pagination);
+        setError(null);
+        setStatus("success");
+      } else {
+        setError(result.error);
+        setStatus("error");
       }
-
-      if (statusFilter !== "all" && !applicationStatuses(app).includes(statusFilter)) {
-        return false;
-      }
-
-      if (committeeFilter !== "all" && !applicationCommittees(app).includes(committeeFilter)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [applications, search, statusFilter, committeeFilter]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [page, debouncedSearch, statusFilter, committeeFilter, cycleFilter]);
 
   return (
     <div className="application-table-wrapper">
       <div className="application-table-wrapper__header">
         <h3>Applications</h3>
         <span className="application-table-wrapper__count">
-          {filtered.length} of {applications.length}
+          {pagination.total} application{pagination.total === 1 ? "" : "s"}
         </span>
       </div>
 
@@ -83,20 +114,16 @@ export default function ApplicationTable({ applications = [], committees = [] })
           className="application-filters__search"
           placeholder="Search by name or email"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => { setSearch(e.target.value); setPage(1); }}
           aria-label="Search applications"
         />
 
         <label className="application-filters__field">
           <span className="application-filters__label">Status</span>
-          <select
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-          >
-            <option value="all">All</option>
-            {statusOptions.map(status => (
-              <option key={status} value={status}>
-                {status}
+          <select value={statusFilter} onChange={e => { setStatusFilter(e.target.value); setPage(1); }}>
+            {STATUS_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>
@@ -104,10 +131,7 @@ export default function ApplicationTable({ applications = [], committees = [] })
 
         <label className="application-filters__field">
           <span className="application-filters__label">Committee</span>
-          <select
-            value={committeeFilter}
-            onChange={e => setCommitteeFilter(e.target.value)}
-          >
+          <select value={committeeFilter} onChange={e => { setCommitteeFilter(e.target.value); setPage(1); }}>
             <option value="all">All</option>
             {committees.map(c => (
               <option key={c.id} value={c.id}>
@@ -116,75 +140,122 @@ export default function ApplicationTable({ applications = [], committees = [] })
             ))}
           </select>
         </label>
+
+        <label className="application-filters__field">
+          <span className="application-filters__label">Cycle</span>
+          <select value={cycleFilter} onChange={e => { setCycleFilter(e.target.value); setPage(1); }}>
+            <option value="current">
+              Current{cycleInfo ? ` (${cycleInfo.currentCycle})` : ""}
+            </option>
+            <option value="archived">Archived (all past cycles)</option>
+            {cycleInfo?.pastCycles?.map(cycle => (
+              <option key={cycle} value={`archived:${cycle}`}>
+                Archived — {cycle}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
-      {filtered.length === 0 ? (
+      {status === "loading" && (
+        <div className="application-table-wrapper__empty">Loading applications…</div>
+      )}
+
+      {status === "error" && (
+        <div className="committee-table-wrapper__error">{error}</div>
+      )}
+
+      {status === "success" && applications.length === 0 && (
         <div className="application-table-wrapper__empty">
-          {applications.length === 0
-            ? "No applications yet."
-            : "No applications match the current filters."}
+          No applications match the current filters.
         </div>
-      ) : (
-        <table className="application-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>University</th>
-              <th>Major</th>
-              <th>Grad Year</th>
-              <th>Committees</th>
-              <th>Status</th>
-              <th>Submitted</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map(app => (
-              <tr key={app._id}>
-                <td>
-                  {app.firstName} {app.lastName}
-                </td>
-                <td>{app.email}</td>
-                <td>{app.university}</td>
-                <td>{app.major}</td>
-                <td>{app.graduationYear ?? "—"}</td>
-                <td>
-                  <div className="application-table__committees">
-                    {[
-                      { id: app.firstChoiceCommittee, rank: "1st" },
-                      { id: app.secondChoiceCommittee, rank: "2nd" },
-                      { id: app.thirdChoiceCommittee, rank: "3rd" },
-                    ]
-                      .filter(c => c.id)
-                      .map(c => (
-                        <span key={c.rank} className="application-table__committee">
-                          <span className="application-table__rank">{c.rank}</span>
-                          {committeeLookup.get(c.id) ?? c.id}
-                        </span>
-                      ))}
-                  </div>
-                </td>
-                <td>
-                  <div className="application-table__status-list">
-                    {[
-                      { rank: "1st", status: app.firstChoiceStatus },
-                      { rank: "2nd", status: app.secondChoiceStatus },
-                      { rank: "3rd", status: app.thirdChoiceStatus },
-                    ]
-                      .filter(s => s.status)
-                      .map(s => (
-                        <span key={s.rank} className="application-table__status">
-                          <span className="application-table__rank">{s.rank}</span>
-                          {s.status}
-                        </span>
-                      ))}
-                  </div>
-                </td>
-                <td>{formatDate(app.submittedAt)}</td>
+      )}
+
+      {status === "success" && applications.length > 0 && (
+        <>
+          <table className="application-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>University</th>
+                <th>Major</th>
+                <th>Grad Year</th>
+                <th>Committees</th>
+                <th>Status</th>
+                <th>Submitted</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {applications.map(app => (
+                <tr key={app._id}>
+                  <td>
+                    {app.firstName} {app.lastName}
+                  </td>
+                  <td>{app.email}</td>
+                  <td>{app.university}</td>
+                  <td>{app.major}</td>
+                  <td>{app.graduationYear ?? "—"}</td>
+                  <td>
+                    <div className="application-table__committees">
+                      {[
+                        { id: app.firstChoiceCommittee, rank: "1st" },
+                        { id: app.secondChoiceCommittee, rank: "2nd" },
+                        { id: app.thirdChoiceCommittee, rank: "3rd" },
+                      ]
+                        .filter(c => c.id)
+                        .map(c => (
+                          <span key={c.rank} className="application-table__committee">
+                            <span className="application-table__rank">{c.rank}</span>
+                            {committeeLookup.get(c.id) ?? c.id}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td>
+                    <div className="application-table__status-list">
+                      {[
+                        { rank: "1st", status: app.firstChoiceStatus },
+                        { rank: "2nd", status: app.secondChoiceStatus },
+                        { rank: "3rd", status: app.thirdChoiceStatus },
+                      ]
+                        .filter(s => s.status)
+                        .map(s => (
+                          <span key={s.rank} className="application-table__status">
+                            <span className="application-table__rank">{s.rank}</span>
+                            {s.status}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td>{formatDate(app.submittedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {pagination.pages > 1 && (
+            <div className="application-table-wrapper__pagination">
+              <button
+                type="button"
+                disabled={page <= 1}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+              >
+                Previous
+              </button>
+              <span>
+                Page {pagination.page} of {pagination.pages}
+              </span>
+              <button
+                type="button"
+                disabled={page >= pagination.pages}
+                onClick={() => setPage(p => Math.min(pagination.pages, p + 1))}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/Internship/ApplicationWizard/Step1Committees/CommitteeGrid.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/CommitteeGrid.jsx
@@ -7,6 +7,7 @@ import { committeesAtom } from "@/lib/atoms";
 
 export default function CommitteeGrid({ selectedCommitteeIds, onToggle }) {
   const committees = useAtomValue(committeesAtom);
+  const activeCommittees = committees.filter((committee) => committee.isActive);
 
   if (!committees || committees.length === 0) {
     return (
@@ -22,7 +23,7 @@ export default function CommitteeGrid({ selectedCommitteeIds, onToggle }) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {committees.map(committee => {
+      {activeCommittees.map((committee) => {
         const idx = selectedCommitteeIds.indexOf(committee.id);
         const rank = idx === -1 ? null : idx + 1;
         return (

--- a/components/Internship/ApplicationWizard/Step1Committees/RankedList.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/RankedList.jsx
@@ -61,7 +61,7 @@ function SortableRow({ id, rank, committeeName, onRemove }) {
   );
 }
 
-export default function RankedList({ selectedCommitteeIds, onReorder, onRemove }) {
+export default function RankedList({ selectedCommitteeIds, resolvedNames, onReorder, onRemove }) {
   const committees = useAtomValue(committeesAtom);
 
   const sensors = useSensors(
@@ -78,8 +78,9 @@ export default function RankedList({ selectedCommitteeIds, onReorder, onRemove }
   }
 
   const lookupName = id => {
-    const match = committees ? committees.find(c => c.id === id) : null;
-    return match ? match.displayName : id;
+    const match = committees ? committees.find(c => c.id === id || String(c._id) === id) : null;
+    if (match) return match.displayName;
+    return resolvedNames?.[id] ?? id;
   };
 
   const handleDragEnd = event => {

--- a/components/Internship/ApplicationWizard/Step1Committees/index.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/index.jsx
@@ -10,6 +10,7 @@ import RankedList from "./RankedList";
 import useStep1Save from "./useStep1Save";
 import { authUserProfileAtom, committeesAtom, myApplicationAtom } from "@/lib/atoms";
 import fetchActiveCommittees from "@/app/actions/internship/fetchActiveCommittees";
+import useResolvedCommitteeNames from "@/lib/hooks/useResolvedCommitteeNames";
 
 export default function Step1Committees({ onValidityChange, flushPendingRef }) {
   const router = useRouter();
@@ -125,6 +126,11 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
     setSelectedCommitteeIds((prev) => prev.filter((id) => id !== committeeId));
   }, []);
 
+  // Selections can include a committee that's since been closed (it won't
+  // be in `committees`, which is active-only) — resolve its name separately
+  // so the ranked list doesn't fall back to showing a raw ObjectId.
+  const resolvedNames = useResolvedCommitteeNames(selectedCommitteeIds, committees);
+
   return (
     <section className="space-y-6">
       <h2 className="text-xl font-semibold text-slate-900">Select your committees</h2>
@@ -170,6 +176,7 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
 
       <RankedList
         selectedCommitteeIds={selectedCommitteeIds}
+        resolvedNames={resolvedNames}
         onReorder={handleReorder}
         onRemove={handleRemove}
       />

--- a/components/Internship/ApplicationWizard/Step1Committees/index.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/index.jsx
@@ -51,10 +51,12 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
     }
   }, [setCommittees]);
 
+  // Always fetch fresh on mount rather than reusing whatever's already in
+  // committeesAtom — a committee's active status can change in the admin
+  // panel at any time, and this atom is shared across the wizard steps, so
+  // treating a non-empty atom as "already loaded" risks a stale snapshot.
   useEffect(() => {
-    if (committees.length === 0) {
-      loadCommittees();
-    }
+    loadCommittees();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/Internship/ApplicationWizard/Step1Committees/useStep1Save.js
+++ b/components/Internship/ApplicationWizard/Step1Committees/useStep1Save.js
@@ -9,27 +9,52 @@ import { myApplicationAtom, responsesByCommitteeAtom } from "@/lib/atoms";
 
 const DEBOUNCE_MS = 500;
 
-function buildBody(ids, responsesMap) {
+function getSelectedCommitteeIds(app) {
+  if (!app) return [];
+  return [app.firstChoiceCommittee, app.secondChoiceCommittee, app.thirdChoiceCommittee].filter(Boolean);
+}
+
+function getSlotResponses(app, slot) {
+  if (!app) return [];
+  if (slot === 0) return Array.isArray(app.firstChoiceResponses) ? app.firstChoiceResponses : [];
+  if (slot === 1) return Array.isArray(app.secondChoiceResponses) ? app.secondChoiceResponses : [];
+  if (slot === 2) return Array.isArray(app.thirdChoiceResponses) ? app.thirdChoiceResponses : [];
+  return [];
+}
+
+function cleanResponses(responses) {
+  if (!Array.isArray(responses)) return [];
+  return responses
+    .filter((r) => r && typeof r.answer === "string" && r.answer.trim() !== "")
+    .map((r) => ({ questionKey: r.questionKey, question: r.question, answer: r.answer }));
+}
+
+function buildResponsesByCommittee(app, responsesMap) {
+  const merged = {};
+  getSelectedCommitteeIds(app).forEach((committeeId, slot) => {
+    merged[committeeId] = cleanResponses(getSlotResponses(app, slot));
+  });
+
+  Object.entries(responsesMap || {}).forEach(([committeeId, responses]) => {
+    merged[committeeId] = cleanResponses(responses);
+  });
+
+  return merged;
+}
+
+function buildBody(ids, responsesMap, app = null) {
   const [first, second, third] = ids;
+  const responsesByCommittee = buildResponsesByCommittee(app, responsesMap);
+
   const body = {
     firstChoiceCommittee: first,
     secondChoiceCommittee: second ?? null,
     thirdChoiceCommittee: third ?? null,
+    firstChoiceResponses: first ? (responsesByCommittee[first] || []) : [],
+    secondChoiceResponses: second ? (responsesByCommittee[second] || []) : [],
+    thirdChoiceResponses: third ? (responsesByCommittee[third] || []) : [],
   };
-  const hasMapEntries = responsesMap && Object.keys(responsesMap).length > 0;
-  if (hasMapEntries) {
-    const cleanResponses = (committeeId) => {
-      if (!committeeId) return [];
-      const arr = responsesMap[committeeId];
-      if (!Array.isArray(arr)) return [];
-      return arr
-        .filter((r) => r && typeof r.answer === "string" && r.answer.trim() !== "")
-        .map((r) => ({ questionKey: r.questionKey, question: r.question, answer: r.answer }));
-    };
-    body.firstChoiceResponses = cleanResponses(first);
-    body.secondChoiceResponses = cleanResponses(second);
-    body.thirdChoiceResponses = cleanResponses(third);
-  }
+
   return body;
 }
 
@@ -90,7 +115,7 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
     setErrorKind(null);
 
     try {
-      const payload = buildBody(ids, responsesByCommitteeRef.current);
+      const payload = buildBody(ids, responsesByCommitteeRef.current, app);
       if (!app || !app._id) {
         const pd = profileDataRef.current;
         if (!pd || !pd.university || !pd.major || typeof pd.graduationYear !== "number") {
@@ -116,7 +141,10 @@ export default function useStep1Save(selectedCommitteeIds, profileData) {
 
         const freshIds = latestIdsRef.current;
         if (freshIds.length > 1) {
-          const r2 = await updateApplication(result.data._id, buildBody(freshIds, responsesByCommitteeRef.current));
+          const r2 = await updateApplication(
+            result.data._id,
+            buildBody(freshIds, responsesByCommitteeRef.current, result.data),
+          );
           if (!r2.success) {
             if (r2.notFound) {
               setError("Application not found");

--- a/components/Internship/ApplicationWizard/Step2Questions/index.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/index.jsx
@@ -81,6 +81,8 @@ export default function Step2Questions({ onValidityChange, flushPendingRef }) {
     };
   }), [selectedCommitteeIds, committeeById, isTabIncomplete]);
 
+  const incompleteTabs = useMemo(() => tabs.filter((tab) => tab.incomplete), [tabs]);
+
   const step2Valid = useMemo(() => {
     if (selectedCommitteeIds.length === 0) return false;
     return selectedCommitteeIds.every((id) => !isTabIncomplete(id));
@@ -135,10 +137,18 @@ export default function Step2Questions({ onValidityChange, flushPendingRef }) {
     <section className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-slate-900">Application questions</h2>
-        <p className="text-sm text-slate-600">Required questions are marked with a red asterisk.</p>
+        <p className="text-sm text-slate-600">
+          Complete the required questions for each selected committee before moving on.
+        </p>
       </div>
 
       <CommitteeTabBar tabs={tabs} activeIndex={safeActiveTabIndex} onChange={setActiveTabIndex} />
+
+      {incompleteTabs.length > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          Still needed: {incompleteTabs.map((tab) => tab.displayName).join(", ")}
+        </div>
+      )}
 
       {activeCommittee && (
         <QuestionForm

--- a/components/Internship/ApplicationWizard/Step2Questions/index.jsx
+++ b/components/Internship/ApplicationWizard/Step2Questions/index.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAtom, useAtomValue } from "jotai";
 
 import CommitteeTabBar from "./CommitteeTabBar";
@@ -25,43 +25,50 @@ function isAnswered(value) {
   return typeof value === "string" && value.trim() !== "";
 }
 
+function getValidResponsesForCommittee(committee, responses) {
+  if (!committee || !Array.isArray(committee.customQuestions) || !Array.isArray(responses)) return [];
+  const validQuestionKeys = new Set(committee.customQuestions.map((q) => q.questionKey));
+  return responses.filter((response) => validQuestionKeys.has(response.questionKey));
+}
+
 export default function Step2Questions({ onValidityChange, flushPendingRef }) {
   const myApplication = useAtomValue(myApplicationAtom);
   const committees = useAtomValue(committeesAtom);
   const [responsesByCommittee, setResponsesByCommittee] = useAtom(responsesByCommitteeAtom);
 
   const [activeTabIndex, setActiveTabIndex] = useState(0);
-  const hydratedRef = useRef(false);
 
   const selectedCommitteeIds = useMemo(() => getSelectedCommitteeIds(myApplication), [myApplication]);
-
-  useEffect(() => {
-    if (hydratedRef.current) return;
-    if (!myApplication) return;
-    const ids = getSelectedCommitteeIds(myApplication);
-    if (ids.length === 0) return;
-    setResponsesByCommittee((prev) => {
-      const next = { ...prev };
-      ids.forEach((id, slot) => {
-        if (!next[id] || next[id].length === 0) {
-          next[id] = getSlotResponses(myApplication, slot);
-        }
-      });
-      return next;
-    });
-    hydratedRef.current = true;
-  }, [myApplication, setResponsesByCommittee]);
-
-  const safeActiveTabIndex =
-    activeTabIndex >= selectedCommitteeIds.length && selectedCommitteeIds.length > 0
-      ? 0
-      : activeTabIndex;
 
   const committeeById = useMemo(() => {
     const map = new Map();
     committees.forEach((c) => { map.set(c.id, c); });
     return map;
   }, [committees]);
+
+  useEffect(() => {
+    if (!myApplication) return;
+    const ids = getSelectedCommitteeIds(myApplication);
+    if (ids.length === 0) return;
+    setResponsesByCommittee((prev) => {
+      const next = { ...prev };
+      ids.forEach((id, slot) => {
+        const slotResponses = getValidResponsesForCommittee(
+          committeeById.get(id),
+          getSlotResponses(myApplication, slot),
+        );
+        if ((!next[id] || next[id].length === 0) && slotResponses.length > 0) {
+          next[id] = slotResponses;
+        }
+      });
+      return next;
+    });
+  }, [committeeById, myApplication, setResponsesByCommittee]);
+
+  const safeActiveTabIndex =
+    activeTabIndex >= selectedCommitteeIds.length && selectedCommitteeIds.length > 0
+      ? 0
+      : activeTabIndex;
 
   const isTabIncomplete = useCallback((committeeId) => {
     const committee = committeeById.get(committeeId);

--- a/components/Internship/ApplicationWizard/Step3Resume/index.jsx
+++ b/components/Internship/ApplicationWizard/Step3Resume/index.jsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtomValue } from "jotai";
+import { useRouter } from "next/navigation";
+
+import useStep3Save from "./useStep3Save";
+import { myApplicationAtom } from "@/lib/atoms";
+
+function isValidPublicUrl(value) {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+export default function Step3Resume({ onValidityChange, flushPendingRef }) {
+  const router = useRouter();
+  const myApplication = useAtomValue(myApplicationAtom);
+  const [resumeUrlInput, setResumeUrlInput] = useState("");
+  const [touched, setTouched] = useState(false);
+
+  const resumeUrl = touched ? resumeUrlInput : (myApplication?.resumeUrl || "");
+
+  const resumeUrlValid = useMemo(() => isValidPublicUrl(resumeUrl), [resumeUrl]);
+
+  useEffect(() => {
+    onValidityChange(resumeUrlValid);
+  }, [resumeUrlValid, onValidityChange]);
+
+  const { saveState, error, errorKind, flushPending, retry } = useStep3Save(
+    resumeUrl,
+    resumeUrlValid,
+  );
+
+  useEffect(() => {
+    if (flushPendingRef) flushPendingRef.current = flushPending;
+    return () => {
+      if (flushPendingRef) flushPendingRef.current = null;
+    };
+  }, [flushPendingRef, flushPending]);
+
+  useEffect(() => {
+    if (errorKind === "notFound" || errorKind === "submittedBlock") {
+      router.replace("/internship");
+    }
+  }, [errorKind, router]);
+
+  const showInvalidMessage = touched && resumeUrl.trim() !== "" && !resumeUrlValid;
+
+  const handleChange = useCallback((event) => {
+    setTouched(true);
+    setResumeUrlInput(event.target.value);
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    if (!touched) {
+      setResumeUrlInput(resumeUrl);
+    }
+    setTouched(true);
+  }, [resumeUrl, touched]);
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Resume</h2>
+        <p className="text-sm text-slate-600">
+          Upload your resume to Google Drive or another online file host, then paste a public link that anyone with the link can open.
+        </p>
+      </div>
+
+      <div className="rounded border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-800">
+        Before continuing, confirm the file sharing setting is public, such as Google Drive&apos;s &quot;Anyone with the link can view&quot; option.
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="internship-resume-url" className="block text-sm font-medium text-slate-700">
+          Public resume link <span className="text-red-600">*</span>
+        </label>
+        <input
+          id="internship-resume-url"
+          type="url"
+          inputMode="url"
+          placeholder="https://drive.google.com/file/d/..."
+          value={resumeUrl}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          className="block w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+          aria-describedby="internship-resume-url-help"
+          aria-invalid={showInvalidMessage}
+        />
+        <p id="internship-resume-url-help" className="text-xs text-slate-500">
+          The link must start with http:// or https:// and be accessible outside your account.
+        </p>
+        {showInvalidMessage && (
+          <p className="text-sm text-red-600">Enter a valid public resume URL before moving on.</p>
+        )}
+      </div>
+
+      <div className="text-xs text-slate-500 text-right">
+        {saveState === "pending" && "Saving..."}
+        {saveState === "saving" && "Saving..."}
+        {saveState === "idle" && myApplication?._id && resumeUrlValid &&
+          `Saved${myApplication.lastModifiedAt ? ` ${new Date(myApplication.lastModifiedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`}
+        {saveState === "error" && (
+          <span className="text-red-600">
+            {error || "Save failed"}{" "}
+            <button type="button" onClick={retry} className="underline ml-1">Retry</button>
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step3Resume/useStep3Save.js
+++ b/components/Internship/ApplicationWizard/Step3Resume/useStep3Save.js
@@ -1,0 +1,161 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import updateApplication from "@/app/actions/internship/updateApplication";
+import { myApplicationAtom } from "@/lib/atoms";
+
+const DEBOUNCE_MS = 500;
+
+export default function useStep3Save(resumeUrl, canSave) {
+  const [myApplication, setMyApplication] = useAtom(myApplicationAtom);
+  const [saveState, setSaveState] = useState("idle");
+  const [error, setError] = useState(null);
+  const [errorKind, setErrorKind] = useState(null);
+
+  const timerRef = useRef(null);
+  const inFlightRef = useRef(null);
+  const latestResumeUrlRef = useRef(resumeUrl);
+  const canSaveRef = useRef(canSave);
+  const appRef = useRef(myApplication);
+  const saveStateRef = useRef(saveState);
+  const errorRef = useRef(error);
+
+  useEffect(() => {
+    latestResumeUrlRef.current = resumeUrl;
+  }, [resumeUrl]);
+
+  useEffect(() => {
+    canSaveRef.current = canSave;
+  }, [canSave]);
+
+  useEffect(() => {
+    appRef.current = myApplication;
+  }, [myApplication]);
+
+  useEffect(() => {
+    saveStateRef.current = saveState;
+  }, [saveState]);
+
+  useEffect(() => {
+    errorRef.current = error;
+  }, [error]);
+
+  const doSave = useCallback(async () => {
+    const app = appRef.current;
+    const nextResumeUrl = latestResumeUrlRef.current.trim();
+
+    if (!app || !app._id || !canSaveRef.current) {
+      setSaveState("idle");
+      return;
+    }
+
+    setSaveState("saving");
+    setError(null);
+    setErrorKind(null);
+
+    try {
+      const result = await updateApplication(app._id, { resumeUrl: nextResumeUrl });
+      if (!result.success) {
+        if (result.notFound) {
+          setError("Application not found");
+          setErrorKind("notFound");
+        } else if (result.submittedBlock) {
+          setError("Application already submitted");
+          setErrorKind("submittedBlock");
+        } else {
+          setError(result.error || "Save failed");
+          setErrorKind("network");
+        }
+        setSaveState("error");
+        return;
+      }
+      setMyApplication(result.data);
+      appRef.current = result.data;
+      setSaveState("idle");
+      setErrorKind(null);
+    } catch (err) {
+      setError((err && err.message) || "Save failed");
+      setSaveState("error");
+      setErrorKind("network");
+    }
+  }, [setMyApplication]);
+
+  const runSave = useCallback(async () => {
+    if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+    const p = doSave();
+    inFlightRef.current = p;
+    try {
+      await p;
+    } finally {
+      if (inFlightRef.current === p) inFlightRef.current = null;
+    }
+  }, [doSave]);
+
+  useEffect(() => {
+    const app = appRef.current;
+    if (!app || !app._id || !canSave || !resumeUrl.trim()) {
+      setSaveState("idle");
+      return undefined;
+    }
+
+    if ((app.resumeUrl || "") === resumeUrl.trim()) {
+      setSaveState("idle");
+      return undefined;
+    }
+
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [resumeUrl, canSave, runSave]);
+
+  const flushPending = useCallback(async () => {
+    if (!appRef.current || !appRef.current._id || !canSaveRef.current) return;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      await runSave();
+    } else if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+
+    if (saveStateRef.current === "error") {
+      throw new Error(errorRef.current || "Save failed");
+    }
+  }, [runSave]);
+
+  const retry = useCallback(() => {
+    setError(null);
+    setErrorKind(null);
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, 0);
+  }, [runSave]);
+
+  return { saveState, error, errorKind, flushPending, retry };
+}

--- a/components/Internship/ApplicationWizard/Step4Review/index.jsx
+++ b/components/Internship/ApplicationWizard/Step4Review/index.jsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtomValue } from "jotai";
+import { useRouter } from "next/navigation";
+
+import useStep4Save from "./useStep4Save";
+import {
+  authUserProfileAtom,
+  committeesAtom,
+  myApplicationAtom,
+  responsesByCommitteeAtom,
+} from "@/lib/atoms";
+
+const MIN_GRADUATION_YEAR = 2020;
+
+function rankLabel(rank) {
+  if (rank === 1) return "1st choice";
+  if (rank === 2) return "2nd choice";
+  if (rank === 3) return "3rd choice";
+  return "Choice";
+}
+
+function getProfileMajor(profile) {
+  return profile && "major" in profile ? profile.major : "";
+}
+
+function getProfileYear(profile) {
+  return profile && "year" in profile && typeof profile.year === "number" ? profile.year : null;
+}
+
+function graduationYearFromProfileYear(year) {
+  if (typeof year !== "number" || year < 1 || year > 5) return "";
+  return new Date().getFullYear() + Math.max(0, 5 - year);
+}
+
+function getSelectedCommitteeIds(app) {
+  if (!app) return [];
+  return [app.firstChoiceCommittee, app.secondChoiceCommittee, app.thirdChoiceCommittee].filter(Boolean);
+}
+
+function getSlotResponses(app, slot) {
+  if (!app) return [];
+  if (slot === 0) return Array.isArray(app.firstChoiceResponses) ? app.firstChoiceResponses : [];
+  if (slot === 1) return Array.isArray(app.secondChoiceResponses) ? app.secondChoiceResponses : [];
+  if (slot === 2) return Array.isArray(app.thirdChoiceResponses) ? app.thirdChoiceResponses : [];
+  return [];
+}
+
+function formatValue(value) {
+  if (value === null || value === undefined || value === "") return "Not provided";
+  return value;
+}
+
+export default function Step4Review({ onValidityChange, flushPendingRef }) {
+  const router = useRouter();
+  const myApplication = useAtomValue(myApplicationAtom);
+  const authProfile = useAtomValue(authUserProfileAtom);
+  const committees = useAtomValue(committeesAtom);
+  const responsesByCommittee = useAtomValue(responsesByCommitteeAtom);
+
+  const profileMajor = getProfileMajor(authProfile);
+  const profileYear = getProfileYear(authProfile);
+  const profileGraduationYear = graduationYearFromProfileYear(profileYear);
+  const displayMajor = myApplication?.major || profileMajor;
+
+  const [phone, setPhone] = useState(myApplication?.phone || "");
+  const [graduationYearInput, setGraduationYearInput] = useState(
+    String(myApplication?.graduationYear || profileGraduationYear || ""),
+  );
+
+  const graduationYear = Number(graduationYearInput);
+  const graduationYearValid =
+    Number.isInteger(graduationYear) && graduationYear >= MIN_GRADUATION_YEAR;
+  const stepValid = Boolean(myApplication?._id && graduationYearValid);
+
+  useEffect(() => {
+    onValidityChange(stepValid);
+  }, [stepValid, onValidityChange]);
+
+  const { saveState, error, errorKind, flushPending, retry } = useStep4Save({
+    phone,
+    graduationYear,
+    canSave: stepValid,
+  });
+
+  useEffect(() => {
+    if (flushPendingRef) flushPendingRef.current = flushPending;
+    return () => {
+      if (flushPendingRef) flushPendingRef.current = null;
+    };
+  }, [flushPendingRef, flushPending]);
+
+  useEffect(() => {
+    if (errorKind === "notFound" || errorKind === "submittedBlock") {
+      router.replace("/internship");
+    }
+  }, [errorKind, router]);
+
+  const committeeById = useMemo(() => {
+    const map = new Map();
+    committees.forEach((committee) => { map.set(committee.id, committee); });
+    return map;
+  }, [committees]);
+
+  const rankedCommittees = useMemo(() => (
+    getSelectedCommitteeIds(myApplication).map((committeeId, index) => {
+      const committee = committeeById.get(committeeId);
+      return {
+        committeeId,
+        rank: index + 1,
+        displayName: committee?.displayName || "Committee",
+        responses: responsesByCommittee[committeeId] || getSlotResponses(myApplication, index),
+      };
+    })
+  ), [committeeById, myApplication, responsesByCommittee]);
+
+  const handleGraduationYearChange = useCallback((event) => {
+    setGraduationYearInput(event.target.value);
+  }, []);
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Review your application</h2>
+        <p className="text-sm text-slate-600">
+          Check your profile details, committee rankings, responses, and resume link before submitting.
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded border border-slate-200 p-4">
+        <h3 className="text-base font-semibold text-slate-900">Profile</h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium text-slate-700">Major</label>
+            <div className="mt-1 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
+              {formatValue(displayMajor)}
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-700">Profile year</label>
+            <div className="mt-1 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800">
+              {profileYear ? `Year ${profileYear}` : "Not provided"}
+            </div>
+          </div>
+          <div>
+            <label htmlFor="internship-phone" className="block text-sm font-medium text-slate-700">
+              Phone
+            </label>
+            <input
+              id="internship-phone"
+              type="tel"
+              value={phone}
+              onChange={(event) => setPhone(event.target.value)}
+              placeholder="Optional"
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+            />
+          </div>
+          <div>
+            <label htmlFor="internship-graduation-year" className="block text-sm font-medium text-slate-700">
+              Graduation year <span className="text-red-600">*</span>
+            </label>
+            <input
+              id="internship-graduation-year"
+              type="number"
+              min={MIN_GRADUATION_YEAR}
+              value={graduationYearInput}
+              onChange={handleGraduationYearChange}
+              className="mt-1 block w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+              aria-invalid={!graduationYearValid}
+            />
+            {!graduationYearValid && (
+              <p className="mt-1 text-sm text-red-600">
+                Enter a graduation year of {MIN_GRADUATION_YEAR} or later.
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="text-xs text-slate-500 text-right">
+          {saveState === "pending" && "Saving..."}
+          {saveState === "saving" && "Saving..."}
+          {saveState === "idle" && myApplication?._id && stepValid &&
+            `Saved${myApplication.lastModifiedAt ? ` ${new Date(myApplication.lastModifiedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`}
+          {saveState === "error" && (
+            <span className="text-red-600">
+              {error || "Save failed"}{" "}
+              <button type="button" onClick={retry} className="underline ml-1">Retry</button>
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4 rounded border border-slate-200 p-4">
+        <h3 className="text-base font-semibold text-slate-900">Resume</h3>
+        {myApplication?.resumeUrl ? (
+          <a
+            href={myApplication.resumeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all text-sm text-blue-700 underline"
+          >
+            {myApplication.resumeUrl}
+          </a>
+        ) : (
+          <p className="text-sm text-slate-500">No resume link saved.</p>
+        )}
+      </div>
+
+      <div className="space-y-4 rounded border border-slate-200 p-4">
+        <h3 className="text-base font-semibold text-slate-900">Committee applications</h3>
+        {rankedCommittees.length === 0 ? (
+          <p className="text-sm text-slate-500">No committee selections saved.</p>
+        ) : (
+          <div className="space-y-5">
+            {rankedCommittees.map((committee) => (
+              <div key={committee.committeeId} className="space-y-3 border-t border-slate-200 pt-4 first:border-t-0 first:pt-0">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{rankLabel(committee.rank)}</p>
+                  <p className="text-sm text-slate-700">{committee.displayName}</p>
+                </div>
+                {committee.responses.length === 0 ? (
+                  <p className="text-sm italic text-slate-500">No responses saved for this committee.</p>
+                ) : (
+                  <dl className="space-y-3">
+                    {committee.responses.map((response) => (
+                      <div key={response.questionKey}>
+                        <dt className="text-sm font-medium text-slate-700">{response.question}</dt>
+                        <dd className="mt-1 whitespace-pre-wrap rounded bg-slate-50 px-3 py-2 text-sm text-slate-800">
+                          {response.answer}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/components/Internship/ApplicationWizard/Step4Review/index.jsx
+++ b/components/Internship/ApplicationWizard/Step4Review/index.jsx
@@ -11,6 +11,7 @@ import {
   myApplicationAtom,
   responsesByCommitteeAtom,
 } from "@/lib/atoms";
+import useResolvedCommitteeNames, { getCommitteeDisplayName } from "@/lib/hooks/useResolvedCommitteeNames";
 
 const MIN_GRADUATION_YEAR = 2020;
 
@@ -97,23 +98,25 @@ export default function Step4Review({ onValidityChange, flushPendingRef }) {
     }
   }, [errorKind, router]);
 
-  const committeeById = useMemo(() => {
-    const map = new Map();
-    committees.forEach((committee) => { map.set(committee.id, committee); });
-    return map;
-  }, [committees]);
+  const selectedCommitteeIds = useMemo(
+    () => getSelectedCommitteeIds(myApplication),
+    [myApplication],
+  );
+
+  // A committee can close between when it was selected and this review step
+  // (e.g. once the cycle ends), dropping it out of `committees`, which is
+  // active-only. Resolve those separately so the review still shows a real
+  // name instead of falling back to "Committee".
+  const resolvedNames = useResolvedCommitteeNames(selectedCommitteeIds, committees);
 
   const rankedCommittees = useMemo(() => (
-    getSelectedCommitteeIds(myApplication).map((committeeId, index) => {
-      const committee = committeeById.get(committeeId);
-      return {
-        committeeId,
-        rank: index + 1,
-        displayName: committee?.displayName || "Committee",
-        responses: responsesByCommittee[committeeId] || getSlotResponses(myApplication, index),
-      };
-    })
-  ), [committeeById, myApplication, responsesByCommittee]);
+    selectedCommitteeIds.map((committeeId, index) => ({
+      committeeId,
+      rank: index + 1,
+      displayName: getCommitteeDisplayName(committees, resolvedNames, committeeId) || "Committee",
+      responses: responsesByCommittee[committeeId] || getSlotResponses(myApplication, index),
+    }))
+  ), [committees, resolvedNames, selectedCommitteeIds, myApplication, responsesByCommittee]);
 
   const handleGraduationYearChange = useCallback((event) => {
     setGraduationYearInput(event.target.value);

--- a/components/Internship/ApplicationWizard/Step4Review/useStep4Save.js
+++ b/components/Internship/ApplicationWizard/Step4Review/useStep4Save.js
@@ -1,0 +1,168 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import updateApplication from "@/app/actions/internship/updateApplication";
+import { myApplicationAtom } from "@/lib/atoms";
+
+const DEBOUNCE_MS = 500;
+
+function normalizePhone(phone) {
+  return phone.trim();
+}
+
+export default function useStep4Save({ phone, graduationYear, canSave }) {
+  const [myApplication, setMyApplication] = useAtom(myApplicationAtom);
+  const [saveState, setSaveState] = useState("idle");
+  const [error, setError] = useState(null);
+  const [errorKind, setErrorKind] = useState(null);
+
+  const timerRef = useRef(null);
+  const inFlightRef = useRef(null);
+  const latestValuesRef = useRef({ phone, graduationYear, canSave });
+  const appRef = useRef(myApplication);
+  const saveStateRef = useRef(saveState);
+  const errorRef = useRef(error);
+
+  useEffect(() => {
+    latestValuesRef.current = { phone, graduationYear, canSave };
+  }, [phone, graduationYear, canSave]);
+
+  useEffect(() => {
+    appRef.current = myApplication;
+  }, [myApplication]);
+
+  useEffect(() => {
+    saveStateRef.current = saveState;
+  }, [saveState]);
+
+  useEffect(() => {
+    errorRef.current = error;
+  }, [error]);
+
+  const doSave = useCallback(async () => {
+    const app = appRef.current;
+    const values = latestValuesRef.current;
+
+    if (!app || !app._id || !values.canSave) {
+      setSaveState("idle");
+      return;
+    }
+
+    setSaveState("saving");
+    setError(null);
+    setErrorKind(null);
+
+    try {
+      const result = await updateApplication(app._id, {
+        phone: normalizePhone(values.phone),
+        graduationYear: values.graduationYear,
+      });
+
+      if (!result.success) {
+        if (result.notFound) {
+          setError("Application not found");
+          setErrorKind("notFound");
+        } else if (result.submittedBlock) {
+          setError("Application already submitted");
+          setErrorKind("submittedBlock");
+        } else {
+          setError(result.error || "Save failed");
+          setErrorKind("network");
+        }
+        setSaveState("error");
+        return;
+      }
+
+      setMyApplication(result.data);
+      appRef.current = result.data;
+      setSaveState("idle");
+      setErrorKind(null);
+    } catch (err) {
+      setError((err && err.message) || "Save failed");
+      setSaveState("error");
+      setErrorKind("network");
+    }
+  }, [setMyApplication]);
+
+  const runSave = useCallback(async () => {
+    if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+
+    const p = doSave();
+    inFlightRef.current = p;
+    try {
+      await p;
+    } finally {
+      if (inFlightRef.current === p) inFlightRef.current = null;
+    }
+  }, [doSave]);
+
+  useEffect(() => {
+    const app = appRef.current;
+    if (!app || !app._id || !canSave) {
+      setSaveState("idle");
+      return undefined;
+    }
+
+    const phoneMatches = (app.phone || "") === normalizePhone(phone);
+    const yearMatches = Number(app.graduationYear) === Number(graduationYear);
+    if (phoneMatches && yearMatches) {
+      setSaveState("idle");
+      return undefined;
+    }
+
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [phone, graduationYear, canSave, runSave]);
+
+  const flushPending = useCallback(async () => {
+    if (!appRef.current || !appRef.current._id || !latestValuesRef.current.canSave) return;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      await runSave();
+    } else if (inFlightRef.current) {
+      try {
+        await inFlightRef.current;
+      } catch {
+        /* empty */
+      }
+    }
+
+    if (saveStateRef.current === "error") {
+      throw new Error(errorRef.current || "Save failed");
+    }
+  }, [runSave]);
+
+  const retry = useCallback(() => {
+    setError(null);
+    setErrorKind(null);
+    setSaveState("pending");
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      runSave();
+    }, 0);
+  }, [runSave]);
+
+  return { saveState, error, errorKind, flushPending, retry };
+}

--- a/components/Internship/ApplicationWizard/index.jsx
+++ b/components/Internship/ApplicationWizard/index.jsx
@@ -6,6 +6,7 @@ import { useAtomValue } from "jotai";
 import WizardProgressBar from "@/components/Internship/WizardProgressBar";
 import Step1Committees from "@/components/Internship/ApplicationWizard/Step1Committees";
 import Step2Questions from "@/components/Internship/ApplicationWizard/Step2Questions";
+import Step3Resume from "@/components/Internship/ApplicationWizard/Step3Resume";
 import { myApplicationAtom } from "@/lib/atoms";
 
 const TOTAL_STEPS = 4;
@@ -15,17 +16,21 @@ export default function ApplicationWizard() {
   const [currentStep, setCurrentStep] = useState(1);
   const [step1Valid, setStep1Valid] = useState(false);
   const [step2Valid, setStep2Valid] = useState(false);
+  const [step3Valid, setStep3Valid] = useState(false);
   const [advancing, setAdvancing] = useState(false);
   const flushPendingStep1Ref = useRef(null);
   const flushPendingStep2Ref = useRef(null);
+  const flushPendingStep3Ref = useRef(null);
   const advancingRef = useRef(false);
   const handleStep1ValidityChange = useCallback((valid) => setStep1Valid(valid), []);
   const handleStep2ValidityChange = useCallback((valid) => setStep2Valid(valid), []);
+  const handleStep3ValidityChange = useCallback((valid) => setStep3Valid(valid), []);
 
   const nextDisabled =
     currentStep === TOTAL_STEPS ||
     (currentStep === 1 && !step1Valid) ||
     (currentStep === 2 && !step2Valid) ||
+    (currentStep === 3 && !step3Valid) ||
     advancing;
 
   const handleNext = async () => {
@@ -38,6 +43,9 @@ export default function ApplicationWizard() {
       }
       if (currentStep === 2 && flushPendingStep2Ref.current) {
         try { await flushPendingStep2Ref.current(); } catch { return; }
+      }
+      if (currentStep === 3 && flushPendingStep3Ref.current) {
+        try { await flushPendingStep3Ref.current(); } catch { return; }
       }
       setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
     } finally {
@@ -68,7 +76,13 @@ export default function ApplicationWizard() {
             flushPendingRef={flushPendingStep2Ref}
           />
         )}
-        {currentStep > 2 && (
+        {currentStep === 3 && (
+          <Step3Resume
+            onValidityChange={handleStep3ValidityChange}
+            flushPendingRef={flushPendingStep3Ref}
+          />
+        )}
+        {currentStep > 3 && (
           <div className="text-slate-500">Step {currentStep} content (coming in a later phase)</div>
         )}
       </div>

--- a/components/Internship/ApplicationWizard/index.jsx
+++ b/components/Internship/ApplicationWizard/index.jsx
@@ -38,24 +38,48 @@ export default function ApplicationWizard() {
     (currentStep === 4 && !step4Valid) ||
     advancing;
 
+  const flushCurrentStep = async () => {
+    if (currentStep === 1 && flushPendingStep1Ref.current) {
+      await flushPendingStep1Ref.current();
+    }
+    if (currentStep === 2 && flushPendingStep2Ref.current) {
+      await flushPendingStep2Ref.current();
+    }
+    if (currentStep === 3 && flushPendingStep3Ref.current) {
+      await flushPendingStep3Ref.current();
+    }
+    if (currentStep === 4 && flushPendingStep4Ref.current) {
+      await flushPendingStep4Ref.current();
+    }
+  };
+
+  const resetNextStepValidity = () => {
+    if (currentStep === 1) setStep2Valid(false);
+    if (currentStep === 2) setStep3Valid(false);
+    if (currentStep === 3) setStep4Valid(false);
+  };
+
   const handleNext = async () => {
     if (advancingRef.current) return;
     advancingRef.current = true;
     setAdvancing(true);
     try {
-      if (currentStep === 1 && flushPendingStep1Ref.current) {
-        try { await flushPendingStep1Ref.current(); } catch { return; }
-      }
-      if (currentStep === 2 && flushPendingStep2Ref.current) {
-        try { await flushPendingStep2Ref.current(); } catch { return; }
-      }
-      if (currentStep === 3 && flushPendingStep3Ref.current) {
-        try { await flushPendingStep3Ref.current(); } catch { return; }
-      }
-      if (currentStep === 4 && flushPendingStep4Ref.current) {
-        try { await flushPendingStep4Ref.current(); } catch { return; }
-      }
+      try { await flushCurrentStep(); } catch { return; }
+      resetNextStepValidity();
       setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
+    } finally {
+      advancingRef.current = false;
+      setAdvancing(false);
+    }
+  };
+
+  const handleBack = async () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
+    setAdvancing(true);
+    try {
+      try { await flushCurrentStep(); } catch { return; }
+      setCurrentStep((s) => Math.max(1, s - 1));
     } finally {
       advancingRef.current = false;
       setAdvancing(false);
@@ -101,8 +125,8 @@ export default function ApplicationWizard() {
         <button
           type="button"
           className="rounded border border-gray-300 px-4 py-2 disabled:opacity-50"
-          onClick={() => setCurrentStep((s) => Math.max(1, s - 1))}
-          disabled={currentStep === 1}
+          onClick={handleBack}
+          disabled={currentStep === 1 || advancing}
         >
           Back
         </button>

--- a/components/Internship/ApplicationWizard/index.jsx
+++ b/components/Internship/ApplicationWizard/index.jsx
@@ -7,6 +7,7 @@ import WizardProgressBar from "@/components/Internship/WizardProgressBar";
 import Step1Committees from "@/components/Internship/ApplicationWizard/Step1Committees";
 import Step2Questions from "@/components/Internship/ApplicationWizard/Step2Questions";
 import Step3Resume from "@/components/Internship/ApplicationWizard/Step3Resume";
+import Step4Review from "@/components/Internship/ApplicationWizard/Step4Review";
 import { myApplicationAtom } from "@/lib/atoms";
 
 const TOTAL_STEPS = 4;
@@ -17,20 +18,24 @@ export default function ApplicationWizard() {
   const [step1Valid, setStep1Valid] = useState(false);
   const [step2Valid, setStep2Valid] = useState(false);
   const [step3Valid, setStep3Valid] = useState(false);
+  const [step4Valid, setStep4Valid] = useState(false);
   const [advancing, setAdvancing] = useState(false);
   const flushPendingStep1Ref = useRef(null);
   const flushPendingStep2Ref = useRef(null);
   const flushPendingStep3Ref = useRef(null);
+  const flushPendingStep4Ref = useRef(null);
   const advancingRef = useRef(false);
   const handleStep1ValidityChange = useCallback((valid) => setStep1Valid(valid), []);
   const handleStep2ValidityChange = useCallback((valid) => setStep2Valid(valid), []);
   const handleStep3ValidityChange = useCallback((valid) => setStep3Valid(valid), []);
+  const handleStep4ValidityChange = useCallback((valid) => setStep4Valid(valid), []);
 
   const nextDisabled =
     currentStep === TOTAL_STEPS ||
     (currentStep === 1 && !step1Valid) ||
     (currentStep === 2 && !step2Valid) ||
     (currentStep === 3 && !step3Valid) ||
+    (currentStep === 4 && !step4Valid) ||
     advancing;
 
   const handleNext = async () => {
@@ -46,6 +51,9 @@ export default function ApplicationWizard() {
       }
       if (currentStep === 3 && flushPendingStep3Ref.current) {
         try { await flushPendingStep3Ref.current(); } catch { return; }
+      }
+      if (currentStep === 4 && flushPendingStep4Ref.current) {
+        try { await flushPendingStep4Ref.current(); } catch { return; }
       }
       setCurrentStep((s) => Math.min(TOTAL_STEPS, s + 1));
     } finally {
@@ -82,8 +90,11 @@ export default function ApplicationWizard() {
             flushPendingRef={flushPendingStep3Ref}
           />
         )}
-        {currentStep > 3 && (
-          <div className="text-slate-500">Step {currentStep} content (coming in a later phase)</div>
+        {currentStep === 4 && (
+          <Step4Review
+            onValidityChange={handleStep4ValidityChange}
+            flushPendingRef={flushPendingStep4Ref}
+          />
         )}
       </div>
       <div className="mt-6 flex gap-2">

--- a/components/Internship/ApplicationWizard/index.jsx
+++ b/components/Internship/ApplicationWizard/index.jsx
@@ -1,25 +1,30 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
-import { useAtomValue } from "jotai";
+import { useAtom } from "jotai";
+import { useRouter } from "next/navigation";
 
 import WizardProgressBar from "@/components/Internship/WizardProgressBar";
 import Step1Committees from "@/components/Internship/ApplicationWizard/Step1Committees";
 import Step2Questions from "@/components/Internship/ApplicationWizard/Step2Questions";
 import Step3Resume from "@/components/Internship/ApplicationWizard/Step3Resume";
 import Step4Review from "@/components/Internship/ApplicationWizard/Step4Review";
+import submitApplication from "@/app/actions/internship/submitApplication";
 import { myApplicationAtom } from "@/lib/atoms";
 
 const TOTAL_STEPS = 4;
 
 export default function ApplicationWizard() {
-  const draft = useAtomValue(myApplicationAtom);
+  const router = useRouter();
+  const [draft, setMyApplication] = useAtom(myApplicationAtom);
   const [currentStep, setCurrentStep] = useState(1);
   const [step1Valid, setStep1Valid] = useState(false);
   const [step2Valid, setStep2Valid] = useState(false);
   const [step3Valid, setStep3Valid] = useState(false);
   const [step4Valid, setStep4Valid] = useState(false);
   const [advancing, setAdvancing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
   const flushPendingStep1Ref = useRef(null);
   const flushPendingStep2Ref = useRef(null);
   const flushPendingStep3Ref = useRef(null);
@@ -31,12 +36,12 @@ export default function ApplicationWizard() {
   const handleStep4ValidityChange = useCallback((valid) => setStep4Valid(valid), []);
 
   const nextDisabled =
-    currentStep === TOTAL_STEPS ||
     (currentStep === 1 && !step1Valid) ||
     (currentStep === 2 && !step2Valid) ||
     (currentStep === 3 && !step3Valid) ||
-    (currentStep === 4 && !step4Valid) ||
     advancing;
+
+  const submitDisabled = !step4Valid || submitting || advancing;
 
   const flushCurrentStep = async () => {
     if (currentStep === 1 && flushPendingStep1Ref.current) {
@@ -86,6 +91,38 @@ export default function ApplicationWizard() {
     }
   };
 
+  const handleSubmit = async () => {
+    if (advancingRef.current) return;
+    advancingRef.current = true;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      try {
+        await flushCurrentStep();
+      } catch (err) {
+        setSubmitError((err && err.message) || "Couldn't save your latest changes. Please retry.");
+        return;
+      }
+
+      if (!draft || !draft._id) {
+        setSubmitError("No application to submit.");
+        return;
+      }
+
+      const result = await submitApplication(draft._id);
+      if (!result.success) {
+        setSubmitError(result.error || "Submit failed");
+        return;
+      }
+
+      setMyApplication(result.data);
+      router.replace("/internship");
+    } finally {
+      advancingRef.current = false;
+      setSubmitting(false);
+    }
+  };
+
   return (
     <div className="mx-auto mt-[calc(61px+2rem)] max-w-3xl p-6">
       {draft && (
@@ -121,23 +158,37 @@ export default function ApplicationWizard() {
           />
         )}
       </div>
-      <div className="mt-6 flex gap-2">
+      <div className="mt-6 flex items-center gap-2">
         <button
           type="button"
           className="rounded border border-gray-300 px-4 py-2 disabled:opacity-50"
           onClick={handleBack}
-          disabled={currentStep === 1 || advancing}
+          disabled={currentStep === 1 || advancing || submitting}
         >
           Back
         </button>
-        <button
-          type="button"
-          className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
-          onClick={handleNext}
-          disabled={nextDisabled}
-        >
-          Next
-        </button>
+        {currentStep === TOTAL_STEPS ? (
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+            onClick={handleSubmit}
+            disabled={submitDisabled}
+          >
+            {submitting ? "Submitting…" : "Submit Application"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
+            onClick={handleNext}
+            disabled={nextDisabled}
+          >
+            Next
+          </button>
+        )}
+        {submitError && (
+          <span className="text-sm text-red-600">{submitError}</span>
+        )}
       </div>
     </div>
   );

--- a/components/Internship/CommitteeForm.jsx
+++ b/components/Internship/CommitteeForm.jsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+function toDateInputValue(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) {
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [description, setDescription] = useState(initialValues?.description ?? "");
+  const [internLimit, setInternLimit] = useState(
+    initialValues?.internLimit != null ? String(initialValues.internLimit) : "",
+  );
+  const [applicationDeadline, setApplicationDeadline] = useState(
+    toDateInputValue(initialValues?.applicationDeadline),
+  );
+  const [isActive, setIsActive] = useState(initialValues?.isActive ?? true);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const trimmedName = name.trim();
+    const payload = {
+      name: trimmedName,
+      displayName: trimmedName,
+      description: description.trim() || undefined,
+      internLimit: internLimit.trim() ? Number(internLimit) : undefined,
+      applicationDeadline: applicationDeadline || undefined,
+      isActive,
+    };
+
+    const result = await onSubmit(payload);
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error);
+    }
+  }
+
+  return (
+    <form className="committee-form" onSubmit={handleSubmit}>
+      {error && <div className="committee-form__error">{error}</div>}
+
+      <label className="committee-form__field">
+        <span className="committee-form__label">Name</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Hack"
+          required
+        />
+        <span className="committee-form__hint">
+          Used to match officer role assignments — keep this stable once applications exist.
+        </span>
+      </label>
+
+      <label className="committee-form__field">
+        <span className="committee-form__label">Description</span>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={4}
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--inline">
+        <span className="committee-form__label">Intern Limit</span>
+        <input
+          type="number"
+          min="0"
+          value={internLimit}
+          onChange={(e) => setInternLimit(e.target.value)}
+          placeholder="No limit"
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--inline">
+        <span className="committee-form__label">Application Deadline</span>
+        <input
+          type="date"
+          value={applicationDeadline}
+          onChange={(e) => setApplicationDeadline(e.target.value)}
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--checkbox">
+        <input
+          type="checkbox"
+          checked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        />
+        <span>Active (accepting applications)</span>
+      </label>
+
+      <div className="committee-form__actions">
+        <button type="submit" className="committee-form__submit" disabled={submitting}>
+          {submitting ? "Saving…" : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/Internship/CommitteeForm.jsx
+++ b/components/Internship/CommitteeForm.jsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import useCustomQuestionsEditor from "@/lib/hooks/useCustomQuestionsEditor";
+import CustomQuestionsEditor from "./CustomQuestionsEditor";
 
 function toDateInputValue(value) {
   if (!value) return "";
@@ -19,6 +21,7 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
     toDateInputValue(initialValues?.applicationDeadline),
   );
   const [isActive, setIsActive] = useState(initialValues?.isActive ?? true);
+  const questionsEditor = useCustomQuestionsEditor(initialValues?.customQuestions);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -28,6 +31,11 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
 
     if (!name.trim()) {
       setError("Name is required.");
+      return;
+    }
+    const questionsError = questionsEditor.validate();
+    if (questionsError) {
+      setError(questionsError);
       return;
     }
 
@@ -42,6 +50,7 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
       internLimit: internLimit.trim() ? Number(internLimit) : undefined,
       applicationDeadline: applicationDeadline || undefined,
       isActive,
+      customQuestions: questionsEditor.toPayload(),
     };
 
     const result = await onSubmit(payload);
@@ -78,6 +87,8 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
           rows={4}
         />
       </label>
+
+      <CustomQuestionsEditor editor={questionsEditor} />
 
       <label className="committee-form__field committee-form__field--inline">
         <span className="committee-form__label">Intern Limit</span>

--- a/components/Internship/CommitteeQuestionsModal.jsx
+++ b/components/Internship/CommitteeQuestionsModal.jsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import useCustomQuestionsEditor from "@/lib/hooks/useCustomQuestionsEditor";
+import CustomQuestionsEditor from "./CustomQuestionsEditor";
+import updateCommitteeQuestions from "@/app/actions/internship/updateCommitteeQuestions";
+import "@/components/Internship/AdminDashboard.scss";
+import "./CommitteeQuestionsModal.scss";
+
+export default function CommitteeQuestionsModal({ committee, onClose, onSaved }) {
+  const questionsEditor = useCustomQuestionsEditor(committee.customQuestions);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSave() {
+    const validationError = questionsEditor.validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const result = await updateCommitteeQuestions(committee.id, questionsEditor.toPayload());
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+
+    onSaved(result.data);
+  }
+
+  return (
+    <div className="committee-questions-modal-wrapper">
+      <div className="committee-questions-modal">
+        <div className="committee-questions-modal__header">
+          <h3>Edit {committee.displayName} Questions</h3>
+          <button
+            type="button"
+            className="committee-questions-modal__close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="committee-questions-modal__body">
+          {error && <div className="committee-form__error">{error}</div>}
+          <CustomQuestionsEditor editor={questionsEditor} />
+        </div>
+
+        <div className="committee-questions-modal__footer">
+          <button
+            type="button"
+            className="committee-questions-modal__cancel"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="committee-form__submit"
+            onClick={handleSave}
+            disabled={submitting}
+          >
+            {submitting ? "Saving…" : "Save Questions"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Internship/CommitteeQuestionsModal.scss
+++ b/components/Internship/CommitteeQuestionsModal.scss
@@ -1,0 +1,82 @@
+@use "@/styles/vars";
+
+.committee-questions-modal-wrapper {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  padding: 1.5rem;
+}
+
+.committee-questions-modal {
+  background: vars.$white;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid vars.$gray1;
+
+    h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+  }
+
+  &__close {
+    appearance: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.3rem;
+    line-height: 1;
+    color: vars.$gray3;
+
+    &:hover {
+      color: vars.$dark-red;
+    }
+  }
+
+  &__body {
+    padding: 1.5rem;
+    overflow-y: auto;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+    border-top: 1px solid vars.$gray1;
+  }
+
+  &__cancel {
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    padding: 0.6rem 1.25rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+
+    &:hover:not(:disabled) {
+      border-color: vars.$gray3;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/components/Internship/CommitteeTable.jsx
+++ b/components/Internship/CommitteeTable.jsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import BulkActionBar from "@/components/Internship/BulkActionBar";
+import ConfirmationModal from "@/components/Modal/confirmationModal";
 import bulkUpdateCommitteeStatus from "@/app/actions/internship/bulkUpdateCommitteeStatus";
+import deleteCommittee from "@/app/actions/internship/deleteCommittee";
+import fetchApplicationCycle from "@/app/actions/internship/fetchApplicationCycle";
+import advanceApplicationCycle from "@/app/actions/internship/advanceApplicationCycle";
 
 function formatDeadline(value) {
   if (!value) return "—";
@@ -12,14 +16,130 @@ function formatDeadline(value) {
   return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
+function CycleControls({ onAdvanced }) {
+  const [expanded, setExpanded] = useState(false);
+  const [info, setInfo] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [newCycle, setNewCycle] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || info) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const result = await fetchApplicationCycle();
+      if (cancelled) return;
+      setLoading(false);
+      if (result.success) {
+        setInfo(result.data);
+        setNewCycle(result.data.suggestedNextCycle);
+      } else {
+        setError(result.error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded, info]);
+
+  async function handleConfirmAdvance() {
+    setConfirming(false);
+    setPending(true);
+    setError(null);
+    const result = await advanceApplicationCycle(newCycle);
+    setPending(false);
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    setExpanded(false);
+    setInfo(null);
+    onAdvanced?.(result);
+  }
+
+  return (
+    <div className="cycle-controls">
+      <button
+        type="button"
+        className="committee-table-wrapper__bulk-btn committee-table-wrapper__bulk-btn--warning"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        Start New Application Cycle
+      </button>
+
+      {expanded && (
+        <div className="cycle-controls__panel">
+          {loading && <div className="cycle-controls__loading">Loading cycle info…</div>}
+          {error && <div className="committee-table-wrapper__error">{error}</div>}
+          {info && (
+            <>
+              <div className="cycle-controls__current">
+                Current cycle: <strong>{info.currentCycle}</strong>
+              </div>
+              <label className="cycle-controls__field">
+                <span>New cycle label</span>
+                <input
+                  type="text"
+                  value={newCycle}
+                  onChange={(e) => setNewCycle(e.target.value)}
+                />
+              </label>
+              <p className="cycle-controls__warning">
+                This archives every committee&apos;s current-cycle applications and makes the
+                cycle above the new current cycle. Applications remain accessible in the
+                past-cycles view.
+              </p>
+              <div className="cycle-controls__actions">
+                <button
+                  type="button"
+                  className="committee-form__danger-btn committee-form__danger-btn--delete"
+                  disabled={pending || !newCycle.trim()}
+                  onClick={() => setConfirming(true)}
+                >
+                  {pending ? "Advancing…" : "Advance Cycle"}
+                </button>
+                <button
+                  type="button"
+                  className="committee-table-wrapper__bulk-btn"
+                  onClick={() => setExpanded(false)}
+                  disabled={pending}
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <ConfirmationModal
+        opened={confirming}
+        title="Start a new application cycle?"
+        message={`This archives every committee's current-cycle applications and sets "${newCycle}" as the new current cycle. This cannot be undone from the UI.`}
+        submit={handleConfirmAdvance}
+        cancel={() => setConfirming(false)}
+      />
+    </div>
+  );
+}
+
 export default function CommitteeTable({ committees, onMutated }) {
   const [selected, setSelected] = useState(() => new Set());
   const [pending, setPending] = useState(false);
   const [error, setError] = useState(null);
+  const [deleteTargetId, setDeleteTargetId] = useState(null);
+  const [cycleNotice, setCycleNotice] = useState(null);
 
   const allIds = useMemo(() => committees.map(c => c.id), [committees]);
   const allChecked = allIds.length > 0 && selected.size === allIds.length;
   const someChecked = selected.size > 0 && !allChecked;
+  const deleteTarget = useMemo(
+    () => committees.find(c => c.id === deleteTargetId) ?? null,
+    [committees, deleteTargetId],
+  );
 
   function toggle(id) {
     setSelected(prev => {
@@ -51,6 +171,20 @@ export default function CommitteeTable({ committees, onMutated }) {
     onMutated?.();
   }
 
+  async function handleConfirmDelete() {
+    const id = deleteTargetId;
+    setDeleteTargetId(null);
+    setPending(true);
+    setError(null);
+    const result = await deleteCommittee(id);
+    setPending(false);
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    onMutated?.();
+  }
+
   return (
     <div className="committee-table-wrapper">
       <div className="committee-table-wrapper__header">
@@ -72,12 +206,21 @@ export default function CommitteeTable({ committees, onMutated }) {
           >
             Close All
           </button>
+          <CycleControls
+            onAdvanced={(result) => {
+              setCycleNotice(
+                `Advanced to cycle ${result.newCycle}. Archived ${result.archivedCount} application${result.archivedCount === 1 ? "" : "s"}.`,
+              );
+              onMutated?.();
+            }}
+          />
           <Link href="/internship/admin/committees/new" className="committee-table__edit-link">
             + Create Committee
           </Link>
         </div>
       </div>
 
+      {cycleNotice && <div className="cycle-controls__notice">{cycleNotice}</div>}
       {error && <div className="committee-table-wrapper__error">{error}</div>}
 
       {selected.size > 0 && (
@@ -142,18 +285,36 @@ export default function CommitteeTable({ committees, onMutated }) {
                 <td>{c.internLimit ?? "—"}</td>
                 <td>{c.applicationCount ?? 0}</td>
                 <td>
-                  <Link
-                    href={`/internship/admin/committees/${c.id}/edit`}
-                    className="committee-table__edit-link"
-                  >
-                    Edit
-                  </Link>
+                  <div className="committee-table__row-actions">
+                    <Link
+                      href={`/internship/admin/committees/${c.id}/edit`}
+                      className="committee-table__edit-link"
+                    >
+                      Edit
+                    </Link>
+                    <button
+                      type="button"
+                      className="committee-table__delete-link"
+                      disabled={pending}
+                      onClick={() => setDeleteTargetId(c.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
+
+      <ConfirmationModal
+        opened={deleteTargetId !== null}
+        title="Delete this committee?"
+        message={`This deactivates "${deleteTarget?.displayName ?? ""}" — it stops accepting applications and disappears from active lists. This can be undone by reactivating it later.`}
+        submit={handleConfirmDelete}
+        cancel={() => setDeleteTargetId(null)}
+      />
     </div>
   );
 }

--- a/components/Internship/CustomQuestionsEditor.jsx
+++ b/components/Internship/CustomQuestionsEditor.jsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+
+const QUESTION_TYPES = [
+  { value: "short_text", label: "Short text" },
+  { value: "long_text", label: "Long text" },
+  { value: "multiple_choice", label: "Multiple choice" },
+];
+
+function QuestionChoices({ choices, onAdd, onRemove }) {
+  const [input, setInput] = useState("");
+
+  function commit() {
+    const trimmed = input.trim();
+    if (trimmed) onAdd(trimmed);
+    setInput("");
+  }
+
+  return (
+    <div className="committee-form__choices">
+      <div className="committee-form__choice-input">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          placeholder="Add a choice and press Enter"
+        />
+        <button type="button" onClick={commit}>
+          Add
+        </button>
+      </div>
+      {choices.length > 0 && (
+        <div className="committee-form__choice-tags">
+          {choices.map((choice) => (
+            <span key={choice} className="committee-form__choice-tag">
+              {choice}
+              <button type="button" aria-label={`Remove ${choice}`} onClick={() => onRemove(choice)}>
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Renders the add/edit/reorder UI for a committee's customQuestions, driven
+// by the state + handlers from useCustomQuestionsEditor. Shared between the
+// admin committee form and the officer's questions-only editor.
+export default function CustomQuestionsEditor({ editor }) {
+  const {
+    questions,
+    addQuestion,
+    updateQuestion,
+    handleQuestionTextChange,
+    handleQuestionKeyChange,
+    removeQuestion,
+    moveQuestion,
+    addChoice,
+    removeChoice,
+  } = editor;
+
+  return (
+    <div className="committee-form__field">
+      <div className="committee-form__questions-header">
+        <span className="committee-form__label">Custom Questions</span>
+        <button type="button" className="committee-form__question-add" onClick={addQuestion}>
+          Add Question
+        </button>
+      </div>
+
+      {questions.length === 0 && (
+        <span className="committee-form__hint">No custom questions yet.</span>
+      )}
+
+      {questions.map((question, index) => (
+        <div key={question.clientId} className="committee-form__question">
+          <div className="committee-form__question-row">
+            <span className="committee-form__question-index">{index + 1}.</span>
+            <input
+              type="text"
+              value={question.questionText}
+              onChange={(e) => handleQuestionTextChange(question.clientId, e.target.value)}
+              placeholder="Question text"
+              className="committee-form__question-text"
+              required
+            />
+            <button
+              type="button"
+              onClick={() => moveQuestion(question.clientId, -1)}
+              disabled={index === 0}
+              aria-label="Move question up"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => moveQuestion(question.clientId, 1)}
+              disabled={index === questions.length - 1}
+              aria-label="Move question down"
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              className="committee-form__question-remove"
+              aria-label="Remove question"
+              onClick={() => removeQuestion(question.clientId)}
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="committee-form__question-row committee-form__question-row--meta">
+            <label className="committee-form__question-key">
+              <span>Key</span>
+              <input
+                type="text"
+                value={question.questionKey}
+                onChange={(e) => handleQuestionKeyChange(question.clientId, e.target.value)}
+                placeholder="auto-generated"
+                required
+              />
+            </label>
+
+            <label className="committee-form__question-type">
+              <span>Type</span>
+              <select
+                value={question.questionType}
+                onChange={(e) => updateQuestion(question.clientId, { questionType: e.target.value })}
+              >
+                {QUESTION_TYPES.map((type) => (
+                  <option key={type.value} value={type.value}>{type.label}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="committee-form__question-required">
+              <input
+                type="checkbox"
+                checked={question.required}
+                onChange={(e) => updateQuestion(question.clientId, { required: e.target.checked })}
+              />
+              <span>Required</span>
+            </label>
+          </div>
+
+          {question.questionType === "multiple_choice" && (
+            <QuestionChoices
+              choices={question.choices}
+              onAdd={(choice) => addChoice(question.clientId, choice)}
+              onRemove={(choice) => removeChoice(question.clientId, choice)}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Internship/CycleStatusBanner.jsx
+++ b/components/Internship/CycleStatusBanner.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { activeCommitteesAtom } from "@/lib/atoms";
 import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
@@ -9,16 +9,31 @@ import "./CycleStatusBanner.scss";
 export default function CycleStatusBanner() {
   const activeCommittees = useAtomValue(activeCommitteesAtom);
   const setActiveCommittees = useSetAtom(activeCommitteesAtom);
+  const hasRequestedRef = useRef(false);
 
   useEffect(() => {
     if (activeCommittees !== null) return;
-    fetchAllCommittees().then(result => {
-      if (result.success) {
-        setActiveCommittees(result.data.filter(c => c.isActive));
-      } else {
+    if (hasRequestedRef.current) return;
+    hasRequestedRef.current = true;
+
+    let cancelled = false;
+    fetchAllCommittees()
+      .then(result => {
+        if (cancelled) return;
+        if (result.success) {
+          setActiveCommittees(result.data.filter(c => c.isActive));
+        } else {
+          setActiveCommittees([]);
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
         setActiveCommittees([]);
-      }
-    });
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeCommittees, setActiveCommittees]);
 
   if (activeCommittees === null) return null;

--- a/components/Internship/CycleStatusBanner.jsx
+++ b/components/Internship/CycleStatusBanner.jsx
@@ -11,8 +11,11 @@ export default function CycleStatusBanner() {
   const setActiveCommittees = useSetAtom(activeCommitteesAtom);
   const hasRequestedRef = useRef(false);
 
+  // Always fetch fresh on mount rather than skipping when activeCommitteesAtom
+  // is already populated — it's shared across components/pages, so treating
+  // it as "already loaded" risks showing a stale snapshot from earlier in
+  // the session (e.g. after an admin opens/closes committees elsewhere).
   useEffect(() => {
-    if (activeCommittees !== null) return;
     if (hasRequestedRef.current) return;
     hasRequestedRef.current = true;
 
@@ -34,7 +37,7 @@ export default function CycleStatusBanner() {
     return () => {
       cancelled = true;
     };
-  }, [activeCommittees, setActiveCommittees]);
+  }, [setActiveCommittees]);
 
   if (activeCommittees === null) return null;
 

--- a/components/Internship/MemberDashboard.jsx
+++ b/components/Internship/MemberDashboard.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSetAtom, useAtomValue } from "jotai";
 import { myApplicationAtom, activeCommitteesAtom } from "@/lib/atoms";
 import fetchOwnApplication from "@/app/actions/internship/fetchOwnApplication";
@@ -15,6 +15,7 @@ export default function MemberDashboard() {
   const activeCommittees = useAtomValue(activeCommitteesAtom);
   const [mounted, setMounted] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const hasRequestedRef = useRef(false);
 
   useEffect(() => {
     Promise.resolve().then(() => setMounted(true));
@@ -22,14 +23,21 @@ export default function MemberDashboard() {
 
   useEffect(() => {
     if (!mounted) return;
+    if (hasRequestedRef.current) return;
+    hasRequestedRef.current = true;
 
     const loadData = async () => {
-      setIsLoading(true);
+      setIsLoading(activeCommittees === null);
 
       try {
+        const applicationPromise = fetchOwnApplication();
+        const committeesPromise = activeCommittees === null
+          ? fetchAllCommittees()
+          : Promise.resolve({ success: true, data: activeCommittees });
+
         const [applicationResult, committeesResult] = await Promise.all([
-          fetchOwnApplication(),
-          fetchAllCommittees(),
+          applicationPromise,
+          committeesPromise,
         ]);
 
         if (applicationResult.success) {
@@ -39,7 +47,7 @@ export default function MemberDashboard() {
         }
 
         if (committeesResult.success) {
-          const active = committeesResult.data;
+          const active = committeesResult.data.filter((committee) => committee.isActive);
           setActiveCommittees(active);
         } else {
           setActiveCommittees([]);
@@ -52,7 +60,7 @@ export default function MemberDashboard() {
     };
 
     loadData();
-  }, [mounted, setMyApplication, setActiveCommittees]);
+  }, [activeCommittees, mounted, setMyApplication, setActiveCommittees]);
 
   if (!mounted) return null;
 

--- a/components/Internship/MemberDashboard.jsx
+++ b/components/Internship/MemberDashboard.jsx
@@ -31,9 +31,11 @@ export default function MemberDashboard() {
 
       try {
         const applicationPromise = fetchOwnApplication();
-        const committeesPromise = activeCommittees === null
-          ? fetchAllCommittees()
-          : Promise.resolve({ success: true, data: activeCommittees });
+        // Always fetch fresh — a committee's active status can change in the
+        // admin panel at any time, and activeCommitteesAtom is shared across
+        // components/pages, so reusing whatever's already in it risks
+        // showing a stale snapshot from earlier in the session.
+        const committeesPromise = fetchAllCommittees();
 
         const [applicationResult, committeesResult] = await Promise.all([
           applicationPromise,

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -14,6 +14,7 @@ import OfficerStatsBar from "@/app/internship/components/OfficerStatsBar";
 import Toast from "@/components/Toast";
 import useDebouncedValue from "@/lib/hooks/useDebouncedValue";
 import { authUserProfileAtom, officerApplicationsAtom } from "@/lib/atoms";
+import CommitteeQuestionsModal from "./CommitteeQuestionsModal";
 import "./OfficerDashboard.scss";
 
 const CHOICE_FIELDS = [
@@ -111,6 +112,7 @@ export default function OfficerDashboard() {
   const [page, setPage] = useState(1);
 
   const [selectedApplicationId, setSelectedApplicationId] = useState(null);
+  const [isQuestionsModalOpen, setIsQuestionsModalOpen] = useState(false);
   const [toast, setToast] = useState({ key: 0, message: "", success: true, visible: false });
 
   const showToast = useCallback((message, success) => {
@@ -256,6 +258,14 @@ export default function OfficerDashboard() {
     loadStatusCounts();
   }, [setApplications, loadStatusCounts]);
 
+  const handleQuestionsSaved = useCallback((updatedCommittee) => {
+    setCommittees((prev) => prev.map((committee) => (
+      committee.id === updatedCommittee.id ? { ...committee, ...updatedCommittee } : committee
+    )));
+    setIsQuestionsModalOpen(false);
+    showToast("Committee questions saved", true);
+  }, [showToast]);
+
   // Walks every server page under the current filters (the on-screen list is
   // only one page of up to PAGE_SIZE) so "copy emails" grabs every matching
   // applicant's email, not just whichever page happens to be displayed.
@@ -328,6 +338,13 @@ export default function OfficerDashboard() {
       <div className="officer-dashboard__header">
         <h2>{myCommittee.displayName}</h2>
         <span className="officer-dashboard__cycle">Cycle {recruitmentCycle}</span>
+        <button
+          type="button"
+          className="officer-dashboard__edit-questions"
+          onClick={() => setIsQuestionsModalOpen(true)}
+        >
+          Edit Questions
+        </button>
       </div>
 
       <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={handleSelectStatus} />
@@ -388,6 +405,14 @@ export default function OfficerDashboard() {
       />
 
       <Toast key={toast.key} showing={toast.visible} message={toast.message} success={toast.success} />
+
+      {isQuestionsModalOpen && (
+        <CommitteeQuestionsModal
+          committee={myCommittee}
+          onClose={() => setIsQuestionsModalOpen(false)}
+          onSaved={handleQuestionsSaved}
+        />
+      )}
     </div>
   );
 }

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -1,11 +1,285 @@
 "use client";
 
-import "./style.scss";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
+
+import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
+import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import ApplicationDetailDrawer from "@/app/internship/components/ApplicationDetailDrawer";
+import ApplicationTable from "@/app/internship/components/ApplicationTable";
+import CopyEmailsButton from "@/app/internship/components/CopyEmailsButton";
+import OfficerFilterBar from "@/app/internship/components/OfficerFilterBar";
+import OfficerStatsBar from "@/app/internship/components/OfficerStatsBar";
+import Toast from "@/components/Toast";
+import useDebouncedValue from "@/lib/hooks/useDebouncedValue";
+import { authUserProfileAtom, officerApplicationsAtom } from "@/lib/atoms";
+import "./OfficerDashboard.scss";
+
+const CHOICE_FIELDS = [
+  {
+    rank: 1,
+    committeeField: "firstChoiceCommittee",
+    statusField: "firstChoiceStatus",
+    responsesField: "firstChoiceResponses",
+    officer1RatingField: "firstChoiceOfficer1Rating",
+    officer2RatingField: "firstChoiceOfficer2Rating",
+    notesField: "firstChoiceNotes",
+  },
+  {
+    rank: 2,
+    committeeField: "secondChoiceCommittee",
+    statusField: "secondChoiceStatus",
+    responsesField: "secondChoiceResponses",
+    officer1RatingField: "secondChoiceOfficer1Rating",
+    officer2RatingField: "secondChoiceOfficer2Rating",
+    notesField: "secondChoiceNotes",
+  },
+  {
+    rank: 3,
+    committeeField: "thirdChoiceCommittee",
+    statusField: "thirdChoiceStatus",
+    responsesField: "thirdChoiceResponses",
+    officer1RatingField: "thirdChoiceOfficer1Rating",
+    officer2RatingField: "thirdChoiceOfficer2Rating",
+    notesField: "thirdChoiceNotes",
+  },
+];
+
+const EMPTY_STATUS_COUNTS = {
+  pending: 0,
+  reviewing: 0,
+  interview_scheduled: 0,
+  accepted: 0,
+  rejected: 0,
+};
+
+function getCurrentApplicationCycle() {
+  const year = new Date().getFullYear();
+  return `${year}-${year + 1}`;
+}
+
+function normalizeCommitteeName(name) {
+  return typeof name === "string" ? name.trim().toLowerCase() : "";
+}
+
+// Each application can list up to 3 committee choices; an officer only cares
+// about the single slot (if any) that matches their own committee. The API
+// already strips response arrays for the other slots — this just picks out
+// the one slot that's actually theirs to look at.
+function enrichForCommittee(application, committeeId) {
+  const match = CHOICE_FIELDS.find((choice) => application[choice.committeeField] === committeeId);
+  if (!match) return null;
+  return {
+    ...application,
+    myChoiceRank: match.rank,
+    myStatusField: match.statusField,
+    myStatus: application[match.statusField],
+    myResponses: Array.isArray(application[match.responsesField]) ? application[match.responsesField] : [],
+    myOfficer1RatingField: match.officer1RatingField,
+    myOfficer1Rating: application[match.officer1RatingField] ?? null,
+    myOfficer2RatingField: match.officer2RatingField,
+    myOfficer2Rating: application[match.officer2RatingField] ?? null,
+    myNotesField: match.notesField,
+    myNotes: application[match.notesField] ?? "",
+  };
+}
 
 export default function OfficerDashboard() {
+  const authProfile = useAtomValue(authUserProfileAtom);
+  const officerCommitteeName = normalizeCommitteeName(
+    authProfile && "committees" in authProfile ? authProfile.committees?.[0] : undefined,
+  );
+
+  const [committees, setCommittees] = useState([]);
+  const [applications, setApplications] = useAtom(officerApplicationsAtom);
+  const [loadStatus, setLoadStatus] = useState("loading");
+  const [loadError, setLoadError] = useState(null);
+
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [choiceFilter, setChoiceFilter] = useState("all");
+  const [searchInput, setSearchInput] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
+
+  const [selectedApplicationId, setSelectedApplicationId] = useState(null);
+  const [toast, setToast] = useState({ key: 0, message: "", success: true, visible: false });
+
+  const showToast = useCallback((message, success) => {
+    setToast((prev) => ({ key: prev.key + 1, message, success, visible: true }));
+  }, []);
+
+  // The Toast component re-arms its hide timer on every prop update where
+  // `showing` is true (not just on a false->true transition), so it must be
+  // flipped back to false explicitly here rather than left permanently true —
+  // otherwise unrelated re-renders (e.g. typing in the search box) would keep
+  // resetting its internal timer and it would never disappear.
+  useEffect(() => {
+    if (!toast.visible) return undefined;
+    const timer = setTimeout(() => setToast((prev) => ({ ...prev, visible: false })), 3000);
+    return () => clearTimeout(timer);
+  }, [toast.key, toast.visible]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoadStatus("loading");
+      const [committeesResult, applicationsResult] = await Promise.all([
+        fetchAllCommittees(),
+        fetchAllApplications(),
+      ]);
+
+      if (cancelled) return;
+
+      if (!committeesResult.success) {
+        setLoadError(committeesResult.error);
+        setLoadStatus("error");
+        return;
+      }
+      if (!applicationsResult.success) {
+        setLoadError(applicationsResult.error);
+        setLoadStatus("error");
+        return;
+      }
+
+      setCommittees(committeesResult.data);
+      setApplications(applicationsResult.data);
+      setLoadError(null);
+      setLoadStatus("success");
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setApplications]);
+
+  const myCommittee = useMemo(() => committees.find((committee) => (
+    normalizeCommitteeName(committee.displayName) === officerCommitteeName
+    || normalizeCommitteeName(committee.name) === officerCommitteeName
+  )), [committees, officerCommitteeName]);
+
+  const recruitmentCycle = applications[0]?.applicationCycle ?? getCurrentApplicationCycle();
+
+  // Recomputed only when the raw application list or the officer's committee
+  // changes — filtering below runs against this instead of re-deriving
+  // rank/status/responses on every keystroke or filter change.
+  const enrichedApplications = useMemo(() => {
+    if (!myCommittee) return [];
+    return applications
+      .map((application) => enrichForCommittee(application, myCommittee.id))
+      .filter(Boolean);
+  }, [applications, myCommittee]);
+
+  const statusCounts = useMemo(() => {
+    const counts = { ...EMPTY_STATUS_COUNTS };
+    enrichedApplications.forEach((application) => {
+      if (application.myStatus in counts) counts[application.myStatus] += 1;
+    });
+    return counts;
+  }, [enrichedApplications]);
+
+  const filteredApplications = useMemo(() => {
+    const term = debouncedSearch.trim().toLowerCase();
+    return enrichedApplications.filter((application) => {
+      if (statusFilter !== "all" && application.myStatus !== statusFilter) return false;
+      if (choiceFilter !== "all" && String(application.myChoiceRank) !== choiceFilter) return false;
+      if (term) {
+        const haystack = `${application.firstName ?? ""} ${application.lastName ?? ""} ${application.email ?? ""}`.toLowerCase();
+        if (!haystack.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [enrichedApplications, statusFilter, choiceFilter, debouncedSearch]);
+
+  const selectedApplication = useMemo(
+    () => enrichedApplications.find((application) => application._id === selectedApplicationId) ?? null,
+    [enrichedApplications, selectedApplicationId],
+  );
+
+  // Writes through the shared atom, so the table and the drawer — both
+  // reading from the same atom — reflect a status/rating/notes change
+  // immediately, regardless of which one triggered it.
+  const handleApplicationChanged = useCallback((applicationId, updatedApplication) => {
+    setApplications((prev) => prev.map((application) => (
+      application._id === applicationId ? { ...application, ...updatedApplication } : application
+    )));
+  }, [setApplications]);
+
+  const handleCopied = useCallback((count) => {
+    showToast(`Copied ${count} email address${count === 1 ? "" : "es"}`, true);
+  }, [showToast]);
+
+  const handleCopyError = useCallback((message) => {
+    showToast(message, false);
+  }, [showToast]);
+
+  if (loadStatus === "loading") {
+    return <div className="officer-dashboard officer-dashboard__placeholder">Loading applications…</div>;
+  }
+
+  if (loadStatus === "error") {
+    return <div className="officer-dashboard officer-dashboard__error">{loadError}</div>;
+  }
+
+  if (!officerCommitteeName) {
+    return (
+      <div className="officer-dashboard officer-dashboard__error">
+        Your account is not assigned to a committee.
+      </div>
+    );
+  }
+
+  if (!myCommittee) {
+    return (
+      <div className="officer-dashboard officer-dashboard__error">
+        Could not find a committee matching &quot;{officerCommitteeName}&quot;.
+      </div>
+    );
+  }
+
   return (
     <div className="officer-dashboard">
-      <h2>Officer Dashboard</h2>
+      <div className="officer-dashboard__header">
+        <h2>{myCommittee.displayName}</h2>
+        <span className="officer-dashboard__cycle">Cycle {recruitmentCycle}</span>
+      </div>
+
+      <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={setStatusFilter} />
+
+      <OfficerFilterBar
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        choiceFilter={choiceFilter}
+        onChoiceFilterChange={setChoiceFilter}
+        searchInput={searchInput}
+        onSearchInputChange={setSearchInput}
+      />
+
+      <div className="officer-dashboard__toolbar">
+        <div className="officer-dashboard__count">
+          {filteredApplications.length} of {enrichedApplications.length} applications
+        </div>
+        <CopyEmailsButton
+          applications={filteredApplications}
+          onCopied={handleCopied}
+          onError={handleCopyError}
+        />
+      </div>
+
+      <ApplicationTable
+        applications={filteredApplications}
+        onApplicationChanged={handleApplicationChanged}
+        onRowClick={setSelectedApplicationId}
+      />
+
+      <ApplicationDetailDrawer
+        application={selectedApplication}
+        onClose={() => setSelectedApplicationId(null)}
+        onApplicationChanged={handleApplicationChanged}
+      />
+
+      <Toast key={toast.key} showing={toast.visible} message={toast.message} success={toast.success} />
     </div>
   );
 }

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAtom, useAtomValue } from "jotai";
 
 import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
 import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import fetchApplicationStatusCounts from "@/app/actions/internship/fetchApplicationStatusCounts";
 import ApplicationDetailDrawer from "@/app/internship/components/ApplicationDetailDrawer";
 import ApplicationTable from "@/app/internship/components/ApplicationTable";
 import CopyEmailsButton from "@/app/internship/components/CopyEmailsButton";
@@ -53,6 +54,8 @@ const EMPTY_STATUS_COUNTS = {
   rejected: 0,
 };
 
+const PAGE_SIZE = 25;
+
 function getCurrentApplicationCycle() {
   const year = new Date().getFullYear();
   return `${year}-${year + 1}`;
@@ -91,14 +94,21 @@ export default function OfficerDashboard() {
   );
 
   const [committees, setCommittees] = useState([]);
+  const [committeesStatus, setCommitteesStatus] = useState("loading");
+  const [committeesError, setCommitteesError] = useState(null);
+
   const [applications, setApplications] = useAtom(officerApplicationsAtom);
+  const [pagination, setPagination] = useState({ page: 1, limit: PAGE_SIZE, total: 0, pages: 0 });
   const [loadStatus, setLoadStatus] = useState("loading");
   const [loadError, setLoadError] = useState(null);
+
+  const [statusCounts, setStatusCounts] = useState(EMPTY_STATUS_COUNTS);
 
   const [statusFilter, setStatusFilter] = useState("all");
   const [choiceFilter, setChoiceFilter] = useState("all");
   const [searchInput, setSearchInput] = useState("");
   const debouncedSearch = useDebouncedValue(searchInput, 300);
+  const [page, setPage] = useState(1);
 
   const [selectedApplicationId, setSelectedApplicationId] = useState(null);
   const [toast, setToast] = useState({ key: 0, message: "", success: true, visible: false });
@@ -120,82 +130,118 @@ export default function OfficerDashboard() {
 
   useEffect(() => {
     let cancelled = false;
+    (async () => {
+      setCommitteesStatus("loading");
+      const result = await fetchAllCommittees();
+      if (cancelled) return;
+      if (result.success) {
+        setCommittees(result.data);
+        setCommitteesError(null);
+        setCommitteesStatus("success");
+      } else {
+        setCommitteesError(result.error);
+        setCommitteesStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-    async function load() {
+  const myCommittee = committees.find((committee) => (
+    normalizeCommitteeName(committee.displayName) === officerCommitteeName
+    || normalizeCommitteeName(committee.name) === officerCommitteeName
+  )) ?? null;
+
+  // Used both for the initial/dependency-driven fetch below and as a manual
+  // re-trigger from handleApplicationChanged (a status edit shifts counts).
+  const loadStatusCounts = useCallback(async () => {
+    if (!myCommittee) return;
+    const result = await fetchApplicationStatusCounts(myCommittee.id);
+    if (result.success) {
+      setStatusCounts({ ...EMPTY_STATUS_COUNTS, ...result.counts });
+    }
+  }, [myCommittee]);
+
+  useEffect(() => {
+    if (!myCommittee) return undefined;
+    let cancelled = false;
+    (async () => {
+      const result = await fetchApplicationStatusCounts(myCommittee.id);
+      if (cancelled || !result.success) return;
+      setStatusCounts({ ...EMPTY_STATUS_COUNTS, ...result.counts });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [myCommittee]);
+
+  // Filter changes reset pagination back to page 1 — done directly in each
+  // handler (below) rather than via a useEffect watching the filter values,
+  // since that would just be an extra render-effect-render round trip for a
+  // state update that's already known at the moment the filter changes.
+  function handleStatusFilterChange(nextStatus) {
+    setStatusFilter(nextStatus);
+    setPage(1);
+  }
+
+  function handleChoiceFilterChange(nextChoice) {
+    setChoiceFilter(nextChoice);
+    setPage(1);
+  }
+
+  function handleSearchInputChange(nextSearch) {
+    setSearchInput(nextSearch);
+    setPage(1);
+  }
+
+  // Deliberately does NOT wait on committees/myCommittee — the backend
+  // already scopes an officer's applications to their own committee via
+  // their JWT, so this request doesn't need committee data first. Gating it
+  // on myCommittee would serialize two independent network round trips
+  // (committees, then applications) instead of firing them in parallel.
+  // myCommittee is only needed for client-side enrichment, which happens
+  // reactively below once both have loaded.
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
       setLoadStatus("loading");
-      const [committeesResult, applicationsResult] = await Promise.all([
-        fetchAllCommittees(),
-        fetchAllApplications(),
-      ]);
-
+      const result = await fetchAllApplications({
+        page,
+        limit: PAGE_SIZE,
+        search: debouncedSearch.trim() || undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+        choiceRank: choiceFilter !== "all" ? choiceFilter : undefined,
+      });
       if (cancelled) return;
 
-      if (!committeesResult.success) {
-        setLoadError(committeesResult.error);
-        setLoadStatus("error");
-        return;
-      }
-      if (!applicationsResult.success) {
-        setLoadError(applicationsResult.error);
+      if (!result.success) {
+        setLoadError(result.error);
         setLoadStatus("error");
         return;
       }
 
-      setCommittees(committeesResult.data);
-      setApplications(applicationsResult.data);
+      setApplications(result.data);
+      setPagination(result.pagination);
       setLoadError(null);
       setLoadStatus("success");
-    }
-
-    load();
+    })();
 
     return () => {
       cancelled = true;
     };
-  }, [setApplications]);
+  }, [page, debouncedSearch, statusFilter, choiceFilter, setApplications]);
 
-  const myCommittee = useMemo(() => committees.find((committee) => (
-    normalizeCommitteeName(committee.displayName) === officerCommitteeName
-    || normalizeCommitteeName(committee.name) === officerCommitteeName
-  )), [committees, officerCommitteeName]);
+  const enrichedApplications = myCommittee
+    ? applications.map((application) => enrichForCommittee(application, myCommittee.id)).filter(Boolean)
+    : [];
 
   const recruitmentCycle = applications[0]?.applicationCycle ?? getCurrentApplicationCycle();
 
-  // Recomputed only when the raw application list or the officer's committee
-  // changes — filtering below runs against this instead of re-deriving
-  // rank/status/responses on every keystroke or filter change.
-  const enrichedApplications = useMemo(() => {
-    if (!myCommittee) return [];
-    return applications
-      .map((application) => enrichForCommittee(application, myCommittee.id))
-      .filter(Boolean);
-  }, [applications, myCommittee]);
-
-  const statusCounts = useMemo(() => {
-    const counts = { ...EMPTY_STATUS_COUNTS };
-    enrichedApplications.forEach((application) => {
-      if (application.myStatus in counts) counts[application.myStatus] += 1;
-    });
-    return counts;
-  }, [enrichedApplications]);
-
-  const filteredApplications = useMemo(() => {
-    const term = debouncedSearch.trim().toLowerCase();
-    return enrichedApplications.filter((application) => {
-      if (statusFilter !== "all" && application.myStatus !== statusFilter) return false;
-      if (choiceFilter !== "all" && String(application.myChoiceRank) !== choiceFilter) return false;
-      if (term) {
-        const haystack = `${application.firstName ?? ""} ${application.lastName ?? ""} ${application.email ?? ""}`.toLowerCase();
-        if (!haystack.includes(term)) return false;
-      }
-      return true;
-    });
-  }, [enrichedApplications, statusFilter, choiceFilter, debouncedSearch]);
-
-  const selectedApplication = useMemo(
-    () => enrichedApplications.find((application) => application._id === selectedApplicationId) ?? null,
-    [enrichedApplications, selectedApplicationId],
-  );
+  const selectedApplication = enrichedApplications.find(
+    (application) => application._id === selectedApplicationId,
+  ) ?? null;
 
   // Writes through the shared atom, so the table and the drawer — both
   // reading from the same atom — reflect a status/rating/notes change
@@ -204,7 +250,38 @@ export default function OfficerDashboard() {
     setApplications((prev) => prev.map((application) => (
       application._id === applicationId ? { ...application, ...updatedApplication } : application
     )));
-  }, [setApplications]);
+    // A status change shifts the stats-pill counts; refetch rather than
+    // trying to patch counts locally (rating/notes changes don't affect
+    // counts, but this stays correct for all mutation types either way).
+    loadStatusCounts();
+  }, [setApplications, loadStatusCounts]);
+
+  // Walks every server page under the current filters (the on-screen list is
+  // only one page of up to PAGE_SIZE) so "copy emails" grabs every matching
+  // applicant's email, not just whichever page happens to be displayed.
+  const handleFetchAllEmails = useCallback(async () => {
+    const emails = [];
+    const fetchOptions = {
+      limit: 100,
+      search: debouncedSearch.trim() || undefined,
+      status: statusFilter !== "all" ? statusFilter : undefined,
+      choiceRank: choiceFilter !== "all" ? choiceFilter : undefined,
+    };
+
+    let currentPage = 1;
+    let totalPages = 1;
+    do {
+      const result = await fetchAllApplications({ ...fetchOptions, page: currentPage });
+      if (!result.success) throw new Error(result.error);
+      result.data.forEach((application) => {
+        if (application.email) emails.push(application.email);
+      });
+      totalPages = result.pagination.pages;
+      currentPage += 1;
+    } while (currentPage <= totalPages);
+
+    return emails;
+  }, [debouncedSearch, statusFilter, choiceFilter]);
 
   const handleCopied = useCallback((count) => {
     showToast(`Copied ${count} email address${count === 1 ? "" : "es"}`, true);
@@ -214,8 +291,16 @@ export default function OfficerDashboard() {
     showToast(message, false);
   }, [showToast]);
 
-  if (loadStatus === "loading") {
+  function handleSelectStatus(nextStatus) {
+    handleStatusFilterChange(nextStatus);
+  }
+
+  if (committeesStatus === "loading" || (committeesStatus === "success" && loadStatus === "loading" && applications.length === 0)) {
     return <div className="officer-dashboard officer-dashboard__placeholder">Loading applications…</div>;
+  }
+
+  if (committeesStatus === "error") {
+    return <div className="officer-dashboard officer-dashboard__error">{committeesError}</div>;
   }
 
   if (loadStatus === "error") {
@@ -245,33 +330,56 @@ export default function OfficerDashboard() {
         <span className="officer-dashboard__cycle">Cycle {recruitmentCycle}</span>
       </div>
 
-      <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={setStatusFilter} />
+      <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={handleSelectStatus} />
 
       <OfficerFilterBar
         statusFilter={statusFilter}
-        onStatusFilterChange={setStatusFilter}
+        onStatusFilterChange={handleStatusFilterChange}
         choiceFilter={choiceFilter}
-        onChoiceFilterChange={setChoiceFilter}
+        onChoiceFilterChange={handleChoiceFilterChange}
         searchInput={searchInput}
-        onSearchInputChange={setSearchInput}
+        onSearchInputChange={handleSearchInputChange}
       />
 
       <div className="officer-dashboard__toolbar">
         <div className="officer-dashboard__count">
-          {filteredApplications.length} of {enrichedApplications.length} applications
+          {pagination.total} application{pagination.total === 1 ? "" : "s"}
         </div>
         <CopyEmailsButton
-          applications={filteredApplications}
+          totalCount={pagination.total}
+          onFetchAllEmails={handleFetchAllEmails}
           onCopied={handleCopied}
           onError={handleCopyError}
         />
       </div>
 
       <ApplicationTable
-        applications={filteredApplications}
+        applications={enrichedApplications}
         onApplicationChanged={handleApplicationChanged}
         onRowClick={setSelectedApplicationId}
       />
+
+      {pagination.pages > 1 && (
+        <div className="officer-dashboard__pagination">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </button>
+          <span>
+            Page {pagination.page} of {pagination.pages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= pagination.pages}
+            onClick={() => setPage((p) => Math.min(pagination.pages, p + 1))}
+          >
+            Next
+          </button>
+        </div>
+      )}
 
       <ApplicationDetailDrawer
         application={selectedApplication}

--- a/components/Internship/OfficerDashboard.scss
+++ b/components/Internship/OfficerDashboard.scss
@@ -22,6 +22,23 @@
     font-weight: 500;
   }
 
+  &__edit-questions {
+    margin-left: auto;
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$primary-color;
+    color: vars.$primary-color;
+    border-radius: 4px;
+    padding: 0.45rem 0.9rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+
+    &:hover {
+      background: vars.$primary-color;
+      color: vars.$white;
+    }
+  }
+
   &__placeholder,
   &__error {
     padding: 2rem;

--- a/components/Internship/OfficerDashboard.scss
+++ b/components/Internship/OfficerDashboard.scss
@@ -45,6 +45,36 @@
     gap: 1rem;
     margin-bottom: 0.75rem;
   }
+
+  &__pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: vars.$gray3;
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      padding: 0.4rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+
+      &:hover:not(:disabled) {
+        border-color: vars.$primary-color;
+        color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+  }
 }
 
 .copy-emails-button {

--- a/components/Internship/OfficerDashboard.scss
+++ b/components/Internship/OfficerDashboard.scss
@@ -1,0 +1,514 @@
+@use "@/styles/vars";
+
+.officer-dashboard {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  &__header {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+
+    h2 {
+      margin: 0;
+    }
+  }
+
+  &__cycle {
+    color: vars.$gray3;
+    font-size: 0.9rem;
+    font-weight: 500;
+  }
+
+  &__placeholder,
+  &__error {
+    padding: 2rem;
+    text-align: center;
+    color: vars.$gray3;
+  }
+
+  &__error {
+    color: vars.$dark-red;
+  }
+
+  &__count {
+    color: vars.$gray3;
+    font-size: 0.85rem;
+  }
+
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.75rem;
+  }
+}
+
+.copy-emails-button {
+  appearance: none;
+  background: vars.$white;
+  color: vars.$primary-color;
+  border: 1px solid vars.$primary-color;
+  padding: 0.4rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover:not(:disabled) {
+    background: vars.$primary-color;
+    color: vars.$white;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.officer-stats-bar {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+
+  &__pill {
+    appearance: none;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px solid vars.$gray1;
+    background: vars.$white;
+    border-radius: 999px;
+    padding: 0.4rem 1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    transition: border-color 0.15s, background 0.15s;
+
+    &:hover {
+      border-color: vars.$primary-color;
+    }
+  }
+
+  &__pill--active {
+    border-color: vars.$primary-color;
+    background: rgba(33, 77, 133, 0.08);
+  }
+
+  &__count {
+    font-weight: 700;
+    font-size: 0.95rem;
+  }
+
+  &__label {
+    color: vars.$gray3;
+  }
+
+  &__pill--active &__label {
+    color: vars.$primary-color;
+  }
+
+  &__pill--pending &__count {
+    color: #92400e;
+  }
+
+  &__pill--reviewing &__count {
+    color: #1e40af;
+  }
+
+  &__pill--interview_scheduled &__count {
+    color: #3730a3;
+  }
+
+  &__pill--accepted &__count {
+    color: vars.$dark-green;
+  }
+
+  &__pill--rejected &__count {
+    color: vars.$dark-red;
+  }
+}
+
+.officer-filter-bar {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  &__search {
+    flex: 1 1 240px;
+    min-width: 200px;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    font-size: 0.9rem;
+
+    &:focus {
+      outline: none;
+      border-color: vars.$primary-color;
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+
+    select {
+      padding: 0.45rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      background: vars.$white;
+      font-size: 0.9rem;
+      min-width: 170px;
+
+      &:focus {
+        outline: none;
+        border-color: vars.$primary-color;
+      }
+    }
+  }
+
+  &__label {
+    color: vars.$gray3;
+    font-weight: 500;
+  }
+}
+
+.officer-application-table__scroll {
+  overflow-x: auto;
+  // Keep the horizontal scrollbar visible (not just on hover/scroll) as a
+  // fallback for narrow windows, since the table can still exceed the
+  // container width even after tightening column widths below.
+  scrollbar-width: auto; // Firefox
+  scrollbar-color: vars.$gray3 vars.$gray1; // Firefox
+
+  &::-webkit-scrollbar {
+    height: 10px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: vars.$gray1;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: vars.$gray3;
+    border-radius: 999px;
+  }
+}
+
+.officer-application-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+
+  &__empty {
+    padding: 2rem;
+    text-align: center;
+    color: vars.$gray3;
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.75rem 0.5rem;
+    border-bottom: 1px solid vars.$gray1;
+    vertical-align: middle;
+  }
+
+  th {
+    font-weight: 600;
+    color: vars.$gray3;
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  tr:hover td {
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  &__row {
+    cursor: pointer;
+  }
+
+  &__email-col {
+    max-width: 400px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  &__notes-col {
+    min-width: 100px;
+    max-width: 200px;
+    vertical-align: top;
+  }
+}
+
+.rating-dropdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  &__select {
+    width: 84px;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid vars.$gray1;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    background: vars.$white;
+    color: vars.$gray3;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    &--yes {
+      background: #dcfce7;
+      color: vars.$dark-green;
+    }
+
+    &--no {
+      background: #fee2e2;
+      color: vars.$dark-red;
+    }
+
+    &--maybe {
+      background: #fef3c7;
+      color: #92400e;
+    }
+  }
+
+  &__error {
+    color: vars.$dark-red;
+    font-size: 0.75rem;
+  }
+}
+
+.notes-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  &__preview {
+    margin: 0;
+    font-size: 0.85rem;
+    color: vars.$primaryblack;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
+  &__textarea {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.4rem 0.5rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    // Height is driven by NotesCell's auto-grow effect (scrollHeight), not
+    // manual resize — resize/overflow must stay off so the two don't fight
+    // and so the full note is always visible without an inner scrollbar.
+    resize: none;
+    overflow: hidden;
+
+    &:focus {
+      outline: none;
+      border-color: vars.$primary-color;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__toggle {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    align-self: flex-start;
+    color: vars.$secondary-color;
+    font-size: 0.78rem;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  &__error {
+    color: vars.$dark-red;
+    font-size: 0.75rem;
+  }
+}
+
+.application-detail-drawer {
+  width: min(960px, 92vw);
+  max-height: 85vh;
+  background: vars.$white;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.25);
+  border-radius: 12px;
+  padding: 2rem;
+  overflow-y: auto;
+  z-index: 1000;
+
+  &__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+
+    h3 {
+      margin: 0;
+    }
+  }
+
+  &__close {
+    appearance: none;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: vars.$gray3;
+
+    &:hover {
+      color: vars.$primaryblack;
+    }
+  }
+
+  &__section {
+    margin-bottom: 1.5rem;
+
+    h4 {
+      margin: 0 0 0.5rem;
+      font-size: 0.95rem;
+    }
+  }
+
+  &__profile {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem 1rem;
+    margin: 0;
+
+    dt {
+      font-size: 0.75rem;
+      color: vars.$gray3;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+
+    dd {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+  }
+
+  &__status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__responses {
+    margin: 0;
+
+    dt {
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    dd {
+      margin: 0 0 1rem;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+    }
+  }
+
+  &__empty {
+    color: vars.$gray3;
+    font-size: 0.85rem;
+  }
+}
+
+.status-update-dropdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  &__select {
+    width: 118px;
+    padding: 0.35rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid vars.$gray1;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    &--pending {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    &--reviewing {
+      background: #dbeafe;
+      color: #1e40af;
+    }
+
+    &--interview_scheduled {
+      background: #e0e7ff;
+      color: #3730a3;
+    }
+
+    &--accepted {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    &--rejected {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+  }
+
+  &__error {
+    color: vars.$dark-red;
+    font-size: 0.75rem;
+  }
+}

--- a/components/Toast/index.jsx
+++ b/components/Toast/index.jsx
@@ -37,9 +37,17 @@ export default class Toast extends React.Component {
     this.setState(prev => Object.assign({}, prev, { showing: false }));
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.showing) {
-      this.showToast(nextProps.message, nextProps.success, nextProps.duration);
+  componentDidUpdate(prevProps) {
+    // Only re-trigger on an actual prop change from the parent, not on
+    // updates caused by this component's own setState (e.g. hideToast) —
+    // otherwise, since `this.props.showing` would still be true, hideToast
+    // would immediately re-arm showToast and the toast would never close.
+    const propsChanged = prevProps.showing !== this.props.showing
+      || prevProps.message !== this.props.message
+      || prevProps.success !== this.props.success;
+
+    if (this.props.showing && propsChanged) {
+      this.showToast(this.props.message, this.props.success, this.props.duration);
     }
   }
 

--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -11,6 +11,7 @@ export const isOfficerAtom = atom<boolean>(false);
 export const adminViewAtom = atom<boolean>(false);
 export const officerViewAtom = atom<boolean>(false);
 export const myApplicationAtom = atom<InternshipApplication | null>(null);
+export const officerApplicationsAtom = atom<InternshipApplication[]>([]);
 export const activeCommitteesAtom = atom<InternshipCommittee[] | null>(null);
 export const committeesAtom = atom<InternshipCommittee[]>([]);
 export const responsesByCommitteeAtom = atom<Record<string, InternshipQuestionResponse[]>>({});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,10 +36,13 @@ const config = {
     },
     internship: {
       applications: "/api/v1/internship/applications",
+      applicationStatusCounts: "/api/v1/internship/applications/status-counts",
       ownApplication: "/api/v1/internship/applications/me",
       committees: "/api/v1/internship/committees",
       committeesAdmin: "/api/v1/internship/committees/admin",
       committeesBulkStatus: "/api/v1/internship/committees/bulk-status",
+      cycle: "/api/v1/internship/cycle",
+      cycleAdvance: "/api/v1/internship/cycle/advance",
     },
     leaderboard: "/api/v1/leaderboard",
     leaderboardAdmin: "/api/v1/leaderboard/admin",

--- a/lib/hooks/useCustomQuestionsEditor.js
+++ b/lib/hooks/useCustomQuestionsEditor.js
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+
+let clientIdCounter = 0;
+function makeClientId() {
+  clientIdCounter += 1;
+  return `q-${clientIdCounter}`;
+}
+
+function slugify(text) {
+  return text.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function uniqueKey(base, takenKeys) {
+  const root = base || "question";
+  if (!takenKeys.has(root)) return root;
+  let i = 2;
+  while (takenKeys.has(`${root}_${i}`)) i += 1;
+  return `${root}_${i}`;
+}
+
+// Shared editing state/logic for a committee's customQuestions array — used
+// by the admin committee form (full committee edit) and the officer's
+// questions-only editor (PUT /committees/:id/questions), so both stay in
+// sync on validation, key auto-generation, and payload shape.
+export default function useCustomQuestionsEditor(initialQuestions) {
+  const [questions, setQuestions] = useState(() => (
+    (initialQuestions ?? []).map((q) => ({
+      clientId: makeClientId(),
+      questionKey: q.questionKey ?? "",
+      questionText: q.questionText ?? "",
+      questionType: q.questionType ?? "short_text",
+      required: q.required ?? true,
+      choices: Array.isArray(q.choices) ? q.choices : [],
+      // Existing questions keep their key stable even if the text is edited —
+      // applicant responses are stored against questionKey, so changing it
+      // on an edit would orphan any answers already saved against it.
+      keyTouched: true,
+    }))
+  ));
+
+  function addQuestion() {
+    setQuestions((prev) => [
+      ...prev,
+      {
+        clientId: makeClientId(),
+        questionKey: "",
+        questionText: "",
+        questionType: "short_text",
+        required: true,
+        choices: [],
+        keyTouched: false,
+      },
+    ]);
+  }
+
+  function updateQuestion(clientId, patch) {
+    setQuestions((prev) => prev.map((q) => (q.clientId === clientId ? { ...q, ...patch } : q)));
+  }
+
+  function handleQuestionTextChange(clientId, text) {
+    setQuestions((prev) => prev.map((q) => {
+      if (q.clientId !== clientId) return q;
+      if (q.keyTouched) return { ...q, questionText: text };
+      const takenKeys = new Set(
+        prev.filter((other) => other.clientId !== clientId).map((other) => other.questionKey),
+      );
+      return { ...q, questionText: text, questionKey: uniqueKey(slugify(text), takenKeys) };
+    }));
+  }
+
+  function handleQuestionKeyChange(clientId, key) {
+    updateQuestion(clientId, { questionKey: key, keyTouched: true });
+  }
+
+  function removeQuestion(clientId) {
+    setQuestions((prev) => prev.filter((q) => q.clientId !== clientId));
+  }
+
+  function moveQuestion(clientId, direction) {
+    setQuestions((prev) => {
+      const idx = prev.findIndex((q) => q.clientId === clientId);
+      const swapWith = idx + direction;
+      if (idx === -1 || swapWith < 0 || swapWith >= prev.length) return prev;
+      const next = [...prev];
+      [next[idx], next[swapWith]] = [next[swapWith], next[idx]];
+      return next;
+    });
+  }
+
+  function addChoice(clientId, choiceText) {
+    setQuestions((prev) => prev.map((q) => (
+      q.clientId === clientId && !q.choices.includes(choiceText)
+        ? { ...q, choices: [...q.choices, choiceText] }
+        : q
+    )));
+  }
+
+  function removeChoice(clientId, choice) {
+    setQuestions((prev) => prev.map((q) => (
+      q.clientId === clientId ? { ...q, choices: q.choices.filter((c) => c !== choice) } : q
+    )));
+  }
+
+  function validate() {
+    if (questions.some((q) => !q.questionText.trim() || !q.questionKey.trim())) {
+      return "Every custom question needs both a key and question text.";
+    }
+    const keys = questions.map((q) => q.questionKey.trim());
+    if (new Set(keys).size !== keys.length) {
+      return "Custom question keys must be unique.";
+    }
+    return null;
+  }
+
+  function toPayload() {
+    return questions.map((q, index) => ({
+      questionKey: q.questionKey.trim(),
+      questionText: q.questionText.trim(),
+      questionType: q.questionType,
+      required: q.required,
+      order: index,
+      choices: q.questionType === "multiple_choice" ? q.choices : [],
+    }));
+  }
+
+  return {
+    questions,
+    addQuestion,
+    updateQuestion,
+    handleQuestionTextChange,
+    handleQuestionKeyChange,
+    removeQuestion,
+    moveQuestion,
+    addChoice,
+    removeChoice,
+    validate,
+    toPayload,
+  };
+}

--- a/lib/hooks/useDebouncedValue.js
+++ b/lib/hooks/useDebouncedValue.js
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function useDebouncedValue(value, delayMs) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/lib/hooks/useResolvedCommitteeNames.js
+++ b/lib/hooks/useResolvedCommitteeNames.js
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import fetchCommitteeById from "@/app/actions/internship/fetchCommitteeById";
+
+// Looks up a committee's display name from an already-loaded (active-only)
+// committee list, without requiring a network round trip for the common case.
+export function getCommitteeDisplayName(knownCommittees, resolvedNames, committeeId) {
+  if (!committeeId) return null;
+  const committee = knownCommittees.find(
+    (c) => c.id === committeeId || String(c._id) === committeeId,
+  );
+  if (committee) return committee.displayName;
+  return resolvedNames[committeeId] ?? null;
+}
+
+// Committee lists elsewhere in the app are filtered to isActive:true, so a
+// committee that's since been closed drops out of them. A member's existing
+// selections/applications can still reference one, though, so this fetches
+// those specific committees by ID (GET /committees/:id has no active-only
+// filter) and caches the resolved names.
+export default function useResolvedCommitteeNames(committeeIds, knownCommittees) {
+  const [resolvedNames, setResolvedNames] = useState({});
+  const idsKey = committeeIds.filter(Boolean).join(",");
+  const knownKey = knownCommittees.map((c) => c.id ?? c._id).join(",");
+
+  useEffect(() => {
+    const missingIds = committeeIds.filter((id) => (
+      id
+      && !knownCommittees.some((c) => c.id === id || String(c._id) === id)
+      && !(id in resolvedNames)
+    ));
+    if (missingIds.length === 0) return undefined;
+
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        missingIds.map(async (id) => {
+          const result = await fetchCommitteeById(id);
+          return [id, result.success ? result.data.displayName : id];
+        }),
+      );
+      if (cancelled) return;
+      setResolvedNames((prev) => ({ ...prev, ...Object.fromEntries(entries) }));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, knownKey]);
+
+  return resolvedNames;
+}

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -64,7 +64,6 @@ export interface InternshipCommittee {
   name: string;
   displayName: string;
   description?: string;
-  subcommittees: string[];
   isActive: boolean;
   internLimit?: number;
   applicationDeadline?: string;
@@ -105,7 +104,6 @@ export type CreateInternshipCommitteePayload = {
   name: string;
   displayName: string;
   description?: string;
-  subcommittees?: string[];
   isActive?: boolean;
   internLimit?: number;
   applicationDeadline?: string | Date;
@@ -114,4 +112,55 @@ export type CreateInternshipCommitteePayload = {
 
 export type CreateInternshipCommitteeResult =
   | { success: true; data: InternshipCommittee }
+  | { success: false; error: string };
+
+export type UpdateInternshipCommitteePayload = Partial<CreateInternshipCommitteePayload>;
+
+export type UpdateInternshipCommitteeResult =
+  | { success: true; data: InternshipCommittee }
+  | { success: false; error: string };
+
+export type DeleteInternshipCommitteeResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type ArchiveCommitteeResult =
+  | { success: true; archivedCount: number }
+  | { success: false; error: string };
+
+export interface InternshipCycleInfo {
+  currentCycle: string;
+  suggestedNextCycle: string;
+  pastCycles: string[];
+}
+
+export type FetchCycleInfoResult =
+  | { success: true; data: InternshipCycleInfo }
+  | { success: false; error: string };
+
+export type AdvanceCycleResult =
+  | { success: true; previousCycle: string; newCycle: string; archivedCount: number }
+  | { success: false; error: string };
+
+export interface FetchApplicationsOptions {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: string;
+  committeeId?: string;
+  choiceRank?: "1" | "2" | "3";
+  applicationCycle?: string;
+  archived?: boolean;
+  includeDrafts?: boolean;
+}
+
+export interface InternshipApplicationsPagination {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+}
+
+export type InternshipApplicationsListResult =
+  | { success: true; data: InternshipApplication[]; pagination: InternshipApplicationsPagination }
   | { success: false; error: string };

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -25,6 +25,15 @@ export interface InternshipApplication {
   firstChoiceStatus: string;
   secondChoiceStatus: string;
   thirdChoiceStatus: string;
+  firstChoiceOfficer1Rating?: "yes" | "no" | "maybe" | null;
+  secondChoiceOfficer1Rating?: "yes" | "no" | "maybe" | null;
+  thirdChoiceOfficer1Rating?: "yes" | "no" | "maybe" | null;
+  firstChoiceOfficer2Rating?: "yes" | "no" | "maybe" | null;
+  secondChoiceOfficer2Rating?: "yes" | "no" | "maybe" | null;
+  thirdChoiceOfficer2Rating?: "yes" | "no" | "maybe" | null;
+  firstChoiceNotes?: string;
+  secondChoiceNotes?: string;
+  thirdChoiceNotes?: string;
   applicationCycle: string;
   submittedAt: string;
   lastModifiedAt: string;


### PR DESCRIPTION
## Description
                                            
- Adds application-cycle tracking (InternshipSettings, cycleController) so admins can view the current/past cycle and advance to a new one, archiving the outgoing cycle's applications per committee.                                      - Adds committee ad/archive) as alighter-weight alternative to deactivation — clears current-cycle appl committee documentitself.
- Adds a per-status application count endpoint (GET /applications/statin dashboards canshow counts without paginating through all applications.
- Frontend: officer and admin dashboards get real cycle/status-count data, a new CommitteeForm for creating/editing committees, and matching server actions (advanceApplicationCycle, archiveCommittee, tionCycle,fetchApplicationStatusCounts, updateCommittee).

## Frontend Specific
- New: CommitteeForm.jsx, cycle/committee/status-count server actions
- Changed: OfficerDashboard, AdminDashboard, CommitteeTable, ApplicationTable, committee edit/new pages, CopyEmailsButton, shared types/config

## Related Issue

Resolves # (issue)

## Steps to view & test changes:
- [ ] npm test in both repos
- [ ] Advance a cycle as admin, confirm outgoing applications archive correctly
- [ ] Archive a single committee, confirm its applications clear without deactivating the committee
- [ ] Officer dashboard status counts match actual application data
- [ ] Create/edit a committee via the new CommitteeForm
- 

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
