### PR TITLE
Feat/internship cycle mgmt

### DIFF
--- a/app/actions/internship/advanceApplicationCycle.ts
+++ b/app/actions/internship/advanceApplicationCycle.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { AdvanceCycleResult } from "@/lib/types/Internship";
+
+export default async function advanceApplicationCycle(newCycle: string): Promise<AdvanceCycleResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.cycleAdvance}`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ newCycle }),
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`advanceApplicationCycle failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return {
+      success: true,
+      previousCycle: data.previousCycle,
+      newCycle: data.newCycle,
+      archivedCount: typeof data.archivedCount === "number" ? data.archivedCount : 0,
+    };
+  } catch (err) {
+    Logger.error(`advanceApplicationCycle failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to advance application cycle." };
+  }
+}

--- a/app/actions/internship/archiveCommittee.ts
+++ b/app/actions/internship/archiveCommittee.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { ArchiveCommitteeResult } from "@/lib/types/Internship";
+
+export default async function archiveCommittee(committeeId: string): Promise<ArchiveCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/archive`,
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`archiveCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return { success: true, archivedCount: typeof data?.archivedCount === "number" ? data.archivedCount : 0 };
+  } catch (err) {
+    Logger.error(`archiveCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to archive committee." };
+  }
+}

--- a/app/actions/internship/deleteCommittee.ts
+++ b/app/actions/internship/deleteCommittee.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { DeleteInternshipCommitteeResult } from "@/lib/types/Internship";
+
+export default async function deleteCommittee(committeeId: string): Promise<DeleteInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`deleteCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    return { success: true };
+  } catch (err) {
+    Logger.error(`deleteCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to delete committee." };
+  }
+}

--- a/app/actions/internship/fetchAllApplications.ts
+++ b/app/actions/internship/fetchAllApplications.ts
@@ -5,13 +5,15 @@ import Config from "@/lib/config";
 import Logger from "@/lib/logger";
 import { isAuthenticated, isTokenAdmin, isTokenOfficer } from "@/lib/token";
 import type {
-  InternshipApplication,
-  InternshipApplicationsResult,
+  FetchApplicationsOptions,
+  InternshipApplicationsListResult,
 } from "@/lib/types/Internship";
 
-const APPLICATIONS_PAGE_LIMIT = 100;
+const DEFAULT_LIMIT = 25;
 
-export default async function fetchAllApplications(): Promise<InternshipApplicationsResult> {
+export default async function fetchAllApplications(
+  options: FetchApplicationsOptions = {},
+): Promise<InternshipApplicationsListResult> {
   try {
     const cks = await cookies();
     const token = cks.get("token")?.value;
@@ -24,7 +26,21 @@ export default async function fetchAllApplications(): Promise<InternshipApplicat
       return { success: false, error: "Not authorized" };
     }
 
-    const url = `${Config.API_URL}${Config.routes.internship.applications}?limit=${APPLICATIONS_PAGE_LIMIT}`;
+    const params = new URLSearchParams();
+    params.set("page", String(options.page ?? 1));
+    params.set("limit", String(options.limit ?? DEFAULT_LIMIT));
+    if (options.search) params.set("search", options.search);
+    // status/committeeId match "any of the application's 3 choice slots",
+    // not a specific slot — see the backend's getAllApplications for why
+    // this can't be done by setting firstChoiceStatus/etc. to the same value.
+    if (options.status) params.set("status", options.status);
+    if (options.committeeId) params.set("committeeId", options.committeeId);
+    if (options.choiceRank) params.set("choiceRank", options.choiceRank);
+    if (options.applicationCycle) params.set("applicationCycle", options.applicationCycle);
+    if (options.archived) params.set("archived", "true");
+    if (options.includeDrafts) params.set("includeDrafts", "true");
+
+    const url = `${Config.API_URL}${Config.routes.internship.applications}?${params.toString()}`;
     const response = await fetch(url, {
       headers: {
         Accept: "application/json",
@@ -42,8 +58,11 @@ export default async function fetchAllApplications(): Promise<InternshipApplicat
       return { success: false, error: message };
     }
 
-    const applications: InternshipApplication[] = data.data ?? [];
-    return { success: true, data: applications };
+    return {
+      success: true,
+      data: data.data ?? [],
+      pagination: data.pagination ?? { page: 1, limit: DEFAULT_LIMIT, total: 0, pages: 0 },
+    };
   } catch (err) {
     Logger.error(`fetchAllApplications failed: ${(err as Error).message}`);
     return { success: false, error: "Failed to fetch applications" };

--- a/app/actions/internship/fetchApplicationCycle.ts
+++ b/app/actions/internship/fetchApplicationCycle.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type { FetchCycleInfoResult, InternshipCycleInfo } from "@/lib/types/Internship";
+
+export default async function fetchApplicationCycle(): Promise<FetchCycleInfoResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(`${Config.API_URL}${Config.routes.internship.cycle}`, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`fetchApplicationCycle failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const info: InternshipCycleInfo = {
+      currentCycle: data.currentCycle,
+      suggestedNextCycle: data.suggestedNextCycle,
+      pastCycles: Array.isArray(data.pastCycles) ? data.pastCycles : [],
+    };
+
+    return { success: true, data: info };
+  } catch (err) {
+    Logger.error(`fetchApplicationCycle failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application cycle." };
+  }
+}

--- a/app/actions/internship/fetchApplicationStatusCounts.ts
+++ b/app/actions/internship/fetchApplicationStatusCounts.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isAuthenticated, isTokenAdmin, isTokenOfficer } from "@/lib/token";
+
+export type FetchApplicationStatusCountsResult =
+  | { success: true; counts: Record<string, number> }
+  | { success: false; error: string };
+
+export default async function fetchApplicationStatusCounts(
+  committeeId?: string,
+): Promise<FetchApplicationStatusCountsResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+
+    if (!isAuthenticated(token)) {
+      return { success: false, error: "Not authenticated" };
+    }
+    if (!isTokenAdmin(token) && !isTokenOfficer(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const params = new URLSearchParams();
+    if (committeeId) params.set("committeeId", committeeId);
+
+    const url = `${Config.API_URL}${Config.routes.internship.applicationStatusCounts}?${params.toString()}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.success === false) {
+      const message = data?.message ?? data?.error ?? `Request failed (${response.status})`;
+      Logger.error(`fetchApplicationStatusCounts failed: ${message}`);
+      return { success: false, error: message };
+    }
+
+    return { success: true, counts: data.counts ?? {} };
+  } catch (err) {
+    Logger.error(`fetchApplicationStatusCounts failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to fetch application status counts" };
+  }
+}

--- a/app/actions/internship/updateCommittee.ts
+++ b/app/actions/internship/updateCommittee.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin } from "@/lib/token";
+import type {
+  UpdateInternshipCommitteePayload,
+  UpdateInternshipCommitteeResult,
+  InternshipCommittee,
+} from "@/lib/types/Internship";
+
+export default async function updateCommittee(
+  committeeId: string,
+  payload: UpdateInternshipCommitteePayload,
+): Promise<UpdateInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/admin`,
+      {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`updateCommittee failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const updated: InternshipCommittee | undefined = data?.committee;
+    if (!updated) {
+      Logger.error("updateCommittee failed: missing committee in response");
+      return { success: false, error: "Failed to update committee." };
+    }
+
+    return { success: true, data: updated };
+  } catch (err) {
+    Logger.error(`updateCommittee failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update committee." };
+  }
+}

--- a/app/actions/internship/updateCommitteeQuestions.ts
+++ b/app/actions/internship/updateCommitteeQuestions.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { cookies } from "next/headers";
+import Config from "@/lib/config";
+import Logger from "@/lib/logger";
+import { isTokenAdmin, isTokenOfficer } from "@/lib/token";
+import type {
+  InternshipCustomQuestion,
+  InternshipCommittee,
+  UpdateInternshipCommitteeResult,
+} from "@/lib/types/Internship";
+
+// Hits PUT /committees/:id/questions — the narrower endpoint officers can
+// use to edit their own committee's questions (backend scopes it via
+// canManageCommitteeResource), as opposed to /committees/:id/admin which
+// is admin-only and covers the full committee record.
+export default async function updateCommitteeQuestions(
+  committeeId: string,
+  customQuestions: InternshipCustomQuestion[],
+): Promise<UpdateInternshipCommitteeResult> {
+  try {
+    const cks = await cookies();
+    const token = cks.get("token")?.value;
+    if (!token) return { success: false, error: "Not authenticated" };
+
+    if (!isTokenAdmin(token) && !isTokenOfficer(token)) {
+      return { success: false, error: "Not authorized" };
+    }
+
+    const response = await fetch(
+      `${Config.API_URL}${Config.routes.internship.committees}/${committeeId}/questions`,
+      {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ customQuestions }),
+      },
+    );
+
+    const data = await response.json().catch(() => null);
+
+    if (!response.ok || data?.error) {
+      const msg =
+        data?.error?.message ??
+        (typeof data?.error === "string" ? data.error : undefined) ??
+        data?.message ??
+        `Request failed (${response.status})`;
+      Logger.error(`updateCommitteeQuestions failed: ${msg}`);
+      return { success: false, error: msg };
+    }
+
+    const updated: InternshipCommittee | undefined = data?.committee;
+    if (!updated) {
+      Logger.error("updateCommitteeQuestions failed: missing committee in response");
+      return { success: false, error: "Failed to update questions." };
+    }
+
+    return { success: true, data: updated };
+  } catch (err) {
+    Logger.error(`updateCommitteeQuestions failed: ${(err as Error).message}`);
+    return { success: false, error: "Failed to update questions." };
+  }
+}

--- a/app/internship/admin/committees/[id]/edit/page.jsx
+++ b/app/internship/admin/committees/[id]/edit/page.jsx
@@ -1,15 +1,155 @@
 "use client";
 
-import { use } from "react";
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import CommitteeForm from "@/components/Internship/CommitteeForm";
+import ConfirmationModal from "@/components/Modal/confirmationModal";
+import fetchCommitteeById from "@/app/actions/internship/fetchCommitteeById";
+import updateCommittee from "@/app/actions/internship/updateCommittee";
+import archiveCommittee from "@/app/actions/internship/archiveCommittee";
+import deleteCommittee from "@/app/actions/internship/deleteCommittee";
+import "@/components/Internship/AdminDashboard.scss";
 
 export default function EditCommitteePage({ params }) {
   const { id } = use(params);
+  const router = useRouter();
+
+  const [committee, setCommittee] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const [dangerError, setDangerError] = useState(null);
+  const [dangerPending, setDangerPending] = useState(false);
+  const [confirmAction, setConfirmAction] = useState(null); // "archive" | "delete" | null
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await fetchCommitteeById(id);
+      if (cancelled) return;
+      if (result.success) {
+        setCommittee(result.data);
+      } else {
+        setLoadError(result.error);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  async function handleSubmit(payload) {
+    const result = await updateCommittee(id, payload);
+    if (result.success) {
+      setCommittee(result.data);
+    }
+    return result;
+  }
+
+  async function handleConfirmDanger() {
+    const action = confirmAction;
+    setConfirmAction(null);
+    setDangerPending(true);
+    setDangerError(null);
+
+    if (action === "archive") {
+      const result = await archiveCommittee(id);
+      setDangerPending(false);
+      if (!result.success) {
+        setDangerError(result.error);
+        return;
+      }
+      window.alert(`Archived ${result.archivedCount} application${result.archivedCount === 1 ? "" : "s"} for this committee.`);
+      return;
+    }
+
+    if (action === "delete") {
+      const result = await deleteCommittee(id);
+      setDangerPending(false);
+      if (!result.success) {
+        setDangerError(result.error);
+        return;
+      }
+      router.push("/internship/admin");
+    }
+  }
+
   return (
     <ProtectedRoute requiredRole="admin">
-      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+      <div className="admin-dashboard">
         <h2>Edit Committee</h2>
-        <p>Committee editor coming soon. Editing committee: <code>{id}</code></p>
+
+        {loading && <div className="admin-dashboard__placeholder">Loading committee…</div>}
+        {!loading && loadError && (
+          <div className="committee-table-wrapper__error">{loadError}</div>
+        )}
+
+        {!loading && committee && (
+          <>
+            <CommitteeForm
+              initialValues={committee}
+              submitLabel="Save Changes"
+              onSubmit={handleSubmit}
+            />
+
+            <div className="committee-form__danger-zone">
+              <h3>Danger Zone</h3>
+              {dangerError && <div className="committee-form__error">{dangerError}</div>}
+              <div className="committee-form__danger-actions">
+                <div className="committee-form__danger-row">
+                  <div>
+                    <strong>Archive this committee&apos;s applications</strong>
+                    <p>
+                      Marks the committee&apos;s current-cycle applications as archived. They&apos;ll
+                      no longer appear in the current Applications view, but stay visible in the
+                      past-cycles view. The committee itself is unaffected.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="committee-form__danger-btn"
+                    disabled={dangerPending}
+                    onClick={() => setConfirmAction("archive")}
+                  >
+                    Archive Applications
+                  </button>
+                </div>
+
+                <div className="committee-form__danger-row">
+                  <div>
+                    <strong>Delete committee</strong>
+                    <p>
+                      Deactivates the committee (it stops accepting applications and disappears
+                      from active lists). This does not delete any existing application data.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="committee-form__danger-btn committee-form__danger-btn--delete"
+                    disabled={dangerPending}
+                    onClick={() => setConfirmAction("delete")}
+                  >
+                    Delete Committee
+                  </button>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        <ConfirmationModal
+          opened={confirmAction !== null}
+          title={confirmAction === "delete" ? "Delete this committee?" : "Archive this committee's applications?"}
+          message={
+            confirmAction === "delete"
+              ? "This deactivates the committee. It will stop accepting applications and disappear from active lists. This can be undone by reactivating it later."
+              : "This archives every current-cycle application for this committee. They'll be hidden from the current Applications view but remain visible in the past-cycles view."
+          }
+          submit={handleConfirmDanger}
+          cancel={() => setConfirmAction(null)}
+        />
       </div>
     </ProtectedRoute>
   );

--- a/app/internship/admin/committees/new/page.jsx
+++ b/app/internship/admin/committees/new/page.jsx
@@ -1,13 +1,27 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import ProtectedRoute from "@/components/Internship/ProtectedRoute";
+import CommitteeForm from "@/components/Internship/CommitteeForm";
+import createCommittee from "@/app/actions/internship/createCommittee";
+import "@/components/Internship/AdminDashboard.scss";
 
 export default function NewCommitteePage() {
+  const router = useRouter();
+
+  async function handleSubmit(payload) {
+    const result = await createCommittee(payload);
+    if (result.success) {
+      router.push("/internship/admin");
+    }
+    return result;
+  }
+
   return (
     <ProtectedRoute requiredRole="admin">
-      <div style={{ padding: "2rem", maxWidth: 1200, margin: "0 auto" }}>
+      <div className="admin-dashboard">
         <h2>Create Committee</h2>
-        <p>Committee editor coming soon.</p>
+        <CommitteeForm submitLabel="Create Committee" onSubmit={handleSubmit} />
       </div>
     </ProtectedRoute>
   );

--- a/app/internship/components/CopyEmailsButton.jsx
+++ b/app/internship/components/CopyEmailsButton.jsx
@@ -2,15 +2,21 @@
 
 import { useState } from "react";
 
-export default function CopyEmailsButton({ applications, onCopied, onError }) {
+// `onFetchAllEmails` (not a static `applications` array) because the
+// underlying application list is now server-paginated — "copy all matching
+// emails" has to walk every page under the current filters, not just
+// whichever page happens to be on screen.
+export default function CopyEmailsButton({ totalCount, onFetchAllEmails, onCopied, onError }) {
   const [copying, setCopying] = useState(false);
 
   const handleClick = async () => {
-    const emails = applications.map((application) => application.email).filter(Boolean);
-    if (emails.length === 0) return;
-
     setCopying(true);
     try {
+      const emails = await onFetchAllEmails();
+      if (emails.length === 0) {
+        setCopying(false);
+        return;
+      }
       await navigator.clipboard.writeText(emails.join(", "));
       onCopied(emails.length);
     } catch (err) {
@@ -25,9 +31,9 @@ export default function CopyEmailsButton({ applications, onCopied, onError }) {
       type="button"
       className="copy-emails-button"
       onClick={handleClick}
-      disabled={copying || applications.length === 0}
+      disabled={copying || totalCount === 0}
     >
-      Copy Emails ({applications.length})
+      {copying ? "Copying…" : `Copy Emails (${totalCount})`}
     </button>
   );
 }

--- a/app/profile/career/page.jsx
+++ b/app/profile/career/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import Topbar from "@/components/Topbar";
 import CareerLanding from "../CareerLanding";
@@ -17,6 +17,7 @@ export default function CareerPage() {
   const activeCommittees = useAtomValue(activeCommitteesAtom);
   const setActiveCommittees = useSetAtom(activeCommitteesAtom);
   const [mounted, setMounted] = useState(false);
+  const hasRequestedCommitteesRef = useRef(false);
   const [careerProfile, setCareerProfile] = useState(userProfile || {});
 
   useEffect(() => {
@@ -35,7 +36,13 @@ export default function CareerPage() {
     })();
   }, [userProfile]);
 
+  // Guarded to run once per mount — without hasRequestedCommitteesRef, this
+  // would loop forever: setActiveCommittees below always produces a new
+  // array, which re-triggers this effect since activeCommittees is a dep.
   useEffect(() => {
+    if (hasRequestedCommitteesRef.current) return;
+    hasRequestedCommitteesRef.current = true;
+
     fetchAllCommittees().then(result => {
       if (result.success) {
         setActiveCommittees(result.data.filter(c => c.isActive));
@@ -43,7 +50,7 @@ export default function CareerPage() {
         setActiveCommittees([]);
       }
     });
-  }, [activeCommittees, setActiveCommittees]);
+  }, [setActiveCommittees]);
 
   const handleLogout = async () => {
     await logoutUser();

--- a/components/Internship/AdminDashboard.jsx
+++ b/components/Internship/AdminDashboard.jsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import CommitteeTable from "@/components/Internship/CommitteeTable";
 import ApplicationTable from "@/components/Internship/ApplicationTable";
 import fetchCommittees from "@/app/actions/internship/fetchCommittees";
-import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
 import "./AdminDashboard.scss";
 
 const TABS = [
@@ -17,9 +16,6 @@ export default function AdminDashboard() {
   const [committees, setCommittees] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [applications, setApplications] = useState([]);
-  const [applicationsStatus, setApplicationsStatus] = useState("idle");
-  const [applicationsError, setApplicationsError] = useState(null);
 
   const loadCommittees = useCallback(async () => {
     setLoading(true);
@@ -33,28 +29,9 @@ export default function AdminDashboard() {
     setLoading(false);
   }, []);
 
-  const loadApplications = useCallback(async () => {
-    setApplicationsStatus("loading");
-    const result = await fetchAllApplications();
-    if (result.success) {
-      setApplications(result.data);
-      setApplicationsError(null);
-      setApplicationsStatus("success");
-    } else {
-      setApplicationsError(result.error);
-      setApplicationsStatus("error");
-    }
-  }, []);
-
   useEffect(() => {
     Promise.resolve().then(loadCommittees);
   }, [loadCommittees]);
-
-  useEffect(() => {
-    if (activeTab === "applications" && applicationsStatus === "idle") {
-      Promise.resolve().then(loadApplications);
-    }
-  }, [activeTab, applicationsStatus, loadApplications]);
 
   return (
     <div className="admin-dashboard">
@@ -88,27 +65,7 @@ export default function AdminDashboard() {
             )}
           </>
         )}
-        {activeTab === "applications" && (
-          <>
-            {applicationsStatus === "loading" && (
-              <div className="admin-dashboard__placeholder">Loading applications…</div>
-            )}
-            {applicationsStatus === "error" && (
-              <div className="committee-table-wrapper__error">
-                {applicationsError}
-                <button
-                  type="button"
-                  onClick={() => setApplicationsStatus("idle")}
-                >
-                  Retry
-                </button>
-              </div>
-            )}
-            {applicationsStatus === "success" && (
-              <ApplicationTable applications={applications} committees={committees} />
-            )}
-          </>
-        )}
+        {activeTab === "applications" && <ApplicationTable committees={committees} />}
       </div>
     </div>
   );

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -82,6 +82,16 @@
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    &--warning {
+      color: vars.$dark-red;
+      border-color: vars.$dark-red;
+
+      &:hover:not(:disabled) {
+        background: vars.$dark-red;
+        color: vars.$white;
+      }
+    }
   }
 
   &__error {
@@ -152,6 +162,95 @@
       text-decoration: underline;
     }
   }
+
+  &__row-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__delete-link {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    color: vars.$dark-red;
+    font-weight: 500;
+    font-size: inherit;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      text-decoration: underline;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.cycle-controls {
+  position: relative;
+
+  &__panel {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    z-index: 10;
+    width: 320px;
+    background: vars.$white;
+    border: 1px solid vars.$gray1;
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__loading {
+    color: vars.$gray3;
+    font-size: 0.85rem;
+  }
+
+  &__current {
+    font-size: 0.9rem;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+
+    input {
+      padding: 0.4rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.9rem;
+    }
+  }
+
+  &__warning {
+    font-size: 0.78rem;
+    color: vars.$gray3;
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__notice {
+    background: rgba(52, 220, 106, 0.12);
+    color: vars.$dark-green;
+    padding: 0.65rem 1rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-size: 0.85rem;
+  }
 }
 
 .application-table-wrapper {
@@ -173,6 +272,36 @@
     padding: 2rem;
     text-align: center;
     color: vars.$gray3;
+  }
+
+  &__pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: vars.$gray3;
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      padding: 0.4rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+
+      &:hover:not(:disabled) {
+        border-color: vars.$primary-color;
+        color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
   }
 }
 
@@ -272,6 +401,156 @@
     font-size: 0.7rem;
     font-weight: 600;
     text-align: center;
+  }
+}
+
+.committee-form {
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1rem;
+
+  &__error {
+    background: rgba(247, 78, 78, 0.1);
+    color: vars.$dark-red;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+
+    input[type="text"],
+    input[type="number"],
+    input[type="date"],
+    textarea {
+      padding: 0.5rem 0.75rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      font-family: inherit;
+
+      &:focus {
+        outline: none;
+        border-color: vars.$primary-color;
+      }
+    }
+
+    &--inline {
+      max-width: 260px;
+    }
+
+    &--checkbox {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
+    }
+  }
+
+  &__label {
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
+  &__hint {
+    font-size: 0.78rem;
+    color: vars.$gray3;
+  }
+
+  &__actions {
+    margin-top: 0.5rem;
+  }
+
+  &__submit {
+    appearance: none;
+    background: vars.$primary-color;
+    color: vars.$white;
+    border: none;
+    padding: 0.6rem 1.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 500;
+
+    &:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__danger-zone {
+    max-width: 700px;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid vars.$gray1;
+
+    h3 {
+      color: vars.$dark-red;
+      font-size: 1rem;
+      margin-bottom: 1rem;
+    }
+  }
+
+  &__danger-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__danger-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem;
+    border: 1px solid rgba(247, 78, 78, 0.3);
+    border-radius: 6px;
+
+    p {
+      margin: 0.25rem 0 0;
+      font-size: 0.82rem;
+      color: vars.$gray3;
+    }
+  }
+
+  &__danger-btn {
+    appearance: none;
+    flex-shrink: 0;
+    background: vars.$white;
+    color: vars.$dark-red;
+    border: 1px solid vars.$dark-red;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+      background: vars.$dark-red;
+      color: vars.$white;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &--delete {
+      background: vars.$dark-red;
+      color: vars.$white;
+
+      &:hover:not(:disabled) {
+        opacity: 0.85;
+      }
+    }
   }
 }
 

--- a/components/Internship/AdminDashboard.scss
+++ b/components/Internship/AdminDashboard.scss
@@ -460,6 +460,180 @@
     color: vars.$gray3;
   }
 
+  &__questions-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__question-add {
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$primary-color;
+    color: vars.$primary-color;
+    border-radius: 4px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-size: 0.82rem;
+
+    &:hover {
+      background: vars.$primary-color;
+      color: vars.$white;
+    }
+  }
+
+  &__question {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 6px;
+  }
+
+  &__question-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    button {
+      appearance: none;
+      background: none;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      cursor: pointer;
+      padding: 0.3rem 0.5rem;
+      font-size: 0.8rem;
+      color: vars.$gray3;
+
+      &:hover:not(:disabled) {
+        color: vars.$primary-color;
+        border-color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+    }
+
+    &--meta {
+      flex-wrap: wrap;
+    }
+  }
+
+  &__question-index {
+    font-size: 0.82rem;
+    color: vars.$gray3;
+    min-width: 1.25rem;
+  }
+
+  &__question-text {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  &__question-remove {
+    color: vars.$dark-red !important;
+    border-color: vars.$dark-red !important;
+  }
+
+  &__question-key,
+  &__question-type {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.78rem;
+    color: vars.$gray3;
+
+    input,
+    select {
+      padding: 0.35rem 0.5rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.82rem;
+      font-family: inherit;
+    }
+  }
+
+  &__question-required {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    align-self: flex-end;
+  }
+
+  &__choices {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__choice-input {
+    display: flex;
+    gap: 0.5rem;
+
+    input {
+      flex: 1;
+      padding: 0.4rem 0.6rem;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      font-size: 0.85rem;
+    }
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$primary-color;
+      color: vars.$primary-color;
+      border-radius: 4px;
+      padding: 0.35rem 0.8rem;
+      cursor: pointer;
+      font-size: 0.82rem;
+
+      &:hover {
+        background: vars.$primary-color;
+        color: vars.$white;
+      }
+    }
+  }
+
+  &__choice-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__choice-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 999px;
+    padding: 0.2rem 0.4rem 0.2rem 0.75rem;
+    font-size: 0.82rem;
+
+    button {
+      appearance: none;
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 1rem;
+      line-height: 1;
+      color: vars.$gray3;
+      padding: 0.1rem 0.3rem;
+
+      &:hover {
+        color: vars.$dark-red;
+      }
+    }
+  }
+
   &__actions {
     margin-top: 0.5rem;
   }

--- a/components/Internship/ApplicationStatusCard.jsx
+++ b/components/Internship/ApplicationStatusCard.jsx
@@ -3,20 +3,23 @@
 import { useAtomValue } from "jotai";
 import Link from "next/link";
 import { myApplicationAtom, activeCommitteesAtom } from "@/lib/atoms";
+import useResolvedCommitteeNames, { getCommitteeDisplayName } from "@/lib/hooks/useResolvedCommitteeNames";
 import ApplicationStatusBadge from "./ApplicationStatusBadge";
 import "./style.scss";
-
-function getCommitteeName(committees, committeeId) {
-  if (!committeeId) return null;
-  const committee = committees.find(
-    (c) => c.id === committeeId || String(c._id) === committeeId,
-  );
-  return committee?.displayName ?? committeeId;
-}
 
 export default function ApplicationStatusCard() {
   const myApplication = useAtomValue(myApplicationAtom);
   const activeCommittees = useAtomValue(activeCommitteesAtom);
+  const committees = activeCommittees ?? [];
+
+  const applicationCommitteeIds = myApplication
+    ? [
+        myApplication.firstChoiceCommittee,
+        myApplication.secondChoiceCommittee,
+        myApplication.thirdChoiceCommittee,
+      ].filter(Boolean)
+    : [];
+  const resolvedNames = useResolvedCommitteeNames(applicationCommitteeIds, committees);
 
   const applicationWizardLink = (
     <Link href="/internship/apply" className="application-status-card__button">
@@ -35,8 +38,6 @@ export default function ApplicationStatusCard() {
       </div>
     );
   }
-
-  const committees = activeCommittees ?? [];
 
   // Branch 1: Open, no application
   if (!myApplication && committees.length > 0) {
@@ -57,9 +58,9 @@ export default function ApplicationStatusCard() {
 
   // Branch 2: Draft
   if (myApplication && myApplication.submissionStatus !== "submitted") {
-    const firstName = getCommitteeName(committees, myApplication.firstChoiceCommittee);
-    const secondName = getCommitteeName(committees, myApplication.secondChoiceCommittee);
-    const thirdName = getCommitteeName(committees, myApplication.thirdChoiceCommittee);
+    const firstName = getCommitteeDisplayName(committees, resolvedNames, myApplication.firstChoiceCommittee);
+    const secondName = getCommitteeDisplayName(committees, resolvedNames, myApplication.secondChoiceCommittee);
+    const thirdName = getCommitteeDisplayName(committees, resolvedNames, myApplication.thirdChoiceCommittee);
 
     return (
       <div className="application-status-card">
@@ -114,7 +115,7 @@ export default function ApplicationStatusCard() {
               <ApplicationStatusBadge
                 key={index}
                 status={choice.status}
-                committeeName={getCommitteeName(committees, choice.committeeId)}
+                committeeName={getCommitteeDisplayName(committees, resolvedNames, choice.committeeId)}
               />
             ))}
           </div>

--- a/components/Internship/ApplicationTable.jsx
+++ b/components/Internship/ApplicationTable.jsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
+import fetchApplicationCycle from "@/app/actions/internship/fetchApplicationCycle";
+import useDebouncedValue from "@/lib/hooks/useDebouncedValue";
+
+const STATUS_OPTIONS = [
+  { value: "all", label: "All statuses" },
+  { value: "pending", label: "Pending" },
+  { value: "reviewing", label: "Reviewing" },
+  { value: "interview_scheduled", label: "Interview Scheduled" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+];
+
+const PAGE_SIZE = 25;
 
 function formatDate(value) {
   if (!value) return "—";
@@ -13,26 +27,32 @@ function formatDate(value) {
   });
 }
 
-function applicationStatuses(application) {
-  return [
-    application.firstChoiceStatus,
-    application.secondChoiceStatus,
-    application.thirdChoiceStatus,
-  ].filter(Boolean);
+// Resolves a cycleFilter selection into the {applicationCycle, archived}
+// params fetchAllApplications expects. "current" intentionally omits both —
+// the backend already defaults to non-archived applications.
+function resolveCycleParams(cycleFilter) {
+  if (cycleFilter === "current") return {};
+  if (cycleFilter === "archived") return { archived: true };
+  if (cycleFilter.startsWith("archived:")) {
+    return { archived: true, applicationCycle: cycleFilter.slice("archived:".length) };
+  }
+  return {};
 }
 
-function applicationCommittees(application) {
-  return [
-    application.firstChoiceCommittee,
-    application.secondChoiceCommittee,
-    application.thirdChoiceCommittee,
-  ].filter(Boolean);
-}
-
-export default function ApplicationTable({ applications = [], committees = [] }) {
+export default function ApplicationTable({ committees = [] }) {
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
   const [statusFilter, setStatusFilter] = useState("all");
   const [committeeFilter, setCommitteeFilter] = useState("all");
+  const [cycleFilter, setCycleFilter] = useState("current");
+  const [page, setPage] = useState(1);
+
+  const [cycleInfo, setCycleInfo] = useState(null);
+
+  const [applications, setApplications] = useState([]);
+  const [pagination, setPagination] = useState({ page: 1, limit: PAGE_SIZE, total: 0, pages: 0 });
+  const [status, setStatus] = useState("loading"); // loading | success | error
+  const [error, setError] = useState(null);
 
   const committeeLookup = useMemo(() => {
     const map = new Map();
@@ -40,40 +60,51 @@ export default function ApplicationTable({ applications = [], committees = [] })
     return map;
   }, [committees]);
 
-  const statusOptions = useMemo(() => {
-    const set = new Set();
-    applications.forEach(app => {
-      applicationStatuses(app).forEach(s => set.add(s));
-    });
-    return Array.from(set).sort();
-  }, [applications]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await fetchApplicationCycle();
+      if (!cancelled && result.success) setCycleInfo(result.data);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-  const filtered = useMemo(() => {
-    const term = search.trim().toLowerCase();
-    return applications.filter(app => {
-      if (term) {
-        const haystack = `${app.firstName ?? ""} ${app.lastName ?? ""} ${app.email ?? ""}`.toLowerCase();
-        if (!haystack.includes(term)) return false;
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setStatus("loading");
+      const result = await fetchAllApplications({
+        page,
+        limit: PAGE_SIZE,
+        search: debouncedSearch.trim() || undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+        committeeId: committeeFilter !== "all" ? committeeFilter : undefined,
+        ...resolveCycleParams(cycleFilter),
+      });
+      if (cancelled) return;
+      if (result.success) {
+        setApplications(result.data);
+        setPagination(result.pagination);
+        setError(null);
+        setStatus("success");
+      } else {
+        setError(result.error);
+        setStatus("error");
       }
-
-      if (statusFilter !== "all" && !applicationStatuses(app).includes(statusFilter)) {
-        return false;
-      }
-
-      if (committeeFilter !== "all" && !applicationCommittees(app).includes(committeeFilter)) {
-        return false;
-      }
-
-      return true;
-    });
-  }, [applications, search, statusFilter, committeeFilter]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [page, debouncedSearch, statusFilter, committeeFilter, cycleFilter]);
 
   return (
     <div className="application-table-wrapper">
       <div className="application-table-wrapper__header">
         <h3>Applications</h3>
         <span className="application-table-wrapper__count">
-          {filtered.length} of {applications.length}
+          {pagination.total} application{pagination.total === 1 ? "" : "s"}
         </span>
       </div>
 
@@ -83,20 +114,16 @@ export default function ApplicationTable({ applications = [], committees = [] })
           className="application-filters__search"
           placeholder="Search by name or email"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={e => { setSearch(e.target.value); setPage(1); }}
           aria-label="Search applications"
         />
 
         <label className="application-filters__field">
           <span className="application-filters__label">Status</span>
-          <select
-            value={statusFilter}
-            onChange={e => setStatusFilter(e.target.value)}
-          >
-            <option value="all">All</option>
-            {statusOptions.map(status => (
-              <option key={status} value={status}>
-                {status}
+          <select value={statusFilter} onChange={e => { setStatusFilter(e.target.value); setPage(1); }}>
+            {STATUS_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>
@@ -104,10 +131,7 @@ export default function ApplicationTable({ applications = [], committees = [] })
 
         <label className="application-filters__field">
           <span className="application-filters__label">Committee</span>
-          <select
-            value={committeeFilter}
-            onChange={e => setCommitteeFilter(e.target.value)}
-          >
+          <select value={committeeFilter} onChange={e => { setCommitteeFilter(e.target.value); setPage(1); }}>
             <option value="all">All</option>
             {committees.map(c => (
               <option key={c.id} value={c.id}>
@@ -116,75 +140,122 @@ export default function ApplicationTable({ applications = [], committees = [] })
             ))}
           </select>
         </label>
+
+        <label className="application-filters__field">
+          <span className="application-filters__label">Cycle</span>
+          <select value={cycleFilter} onChange={e => { setCycleFilter(e.target.value); setPage(1); }}>
+            <option value="current">
+              Current{cycleInfo ? ` (${cycleInfo.currentCycle})` : ""}
+            </option>
+            <option value="archived">Archived (all past cycles)</option>
+            {cycleInfo?.pastCycles?.map(cycle => (
+              <option key={cycle} value={`archived:${cycle}`}>
+                Archived — {cycle}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
-      {filtered.length === 0 ? (
+      {status === "loading" && (
+        <div className="application-table-wrapper__empty">Loading applications…</div>
+      )}
+
+      {status === "error" && (
+        <div className="committee-table-wrapper__error">{error}</div>
+      )}
+
+      {status === "success" && applications.length === 0 && (
         <div className="application-table-wrapper__empty">
-          {applications.length === 0
-            ? "No applications yet."
-            : "No applications match the current filters."}
+          No applications match the current filters.
         </div>
-      ) : (
-        <table className="application-table">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Email</th>
-              <th>University</th>
-              <th>Major</th>
-              <th>Grad Year</th>
-              <th>Committees</th>
-              <th>Status</th>
-              <th>Submitted</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map(app => (
-              <tr key={app._id}>
-                <td>
-                  {app.firstName} {app.lastName}
-                </td>
-                <td>{app.email}</td>
-                <td>{app.university}</td>
-                <td>{app.major}</td>
-                <td>{app.graduationYear ?? "—"}</td>
-                <td>
-                  <div className="application-table__committees">
-                    {[
-                      { id: app.firstChoiceCommittee, rank: "1st" },
-                      { id: app.secondChoiceCommittee, rank: "2nd" },
-                      { id: app.thirdChoiceCommittee, rank: "3rd" },
-                    ]
-                      .filter(c => c.id)
-                      .map(c => (
-                        <span key={c.rank} className="application-table__committee">
-                          <span className="application-table__rank">{c.rank}</span>
-                          {committeeLookup.get(c.id) ?? c.id}
-                        </span>
-                      ))}
-                  </div>
-                </td>
-                <td>
-                  <div className="application-table__status-list">
-                    {[
-                      { rank: "1st", status: app.firstChoiceStatus },
-                      { rank: "2nd", status: app.secondChoiceStatus },
-                      { rank: "3rd", status: app.thirdChoiceStatus },
-                    ]
-                      .filter(s => s.status)
-                      .map(s => (
-                        <span key={s.rank} className="application-table__status">
-                          <span className="application-table__rank">{s.rank}</span>
-                          {s.status}
-                        </span>
-                      ))}
-                  </div>
-                </td>
-                <td>{formatDate(app.submittedAt)}</td>
+      )}
+
+      {status === "success" && applications.length > 0 && (
+        <>
+          <table className="application-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>University</th>
+                <th>Major</th>
+                <th>Grad Year</th>
+                <th>Committees</th>
+                <th>Status</th>
+                <th>Submitted</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {applications.map(app => (
+                <tr key={app._id}>
+                  <td>
+                    {app.firstName} {app.lastName}
+                  </td>
+                  <td>{app.email}</td>
+                  <td>{app.university}</td>
+                  <td>{app.major}</td>
+                  <td>{app.graduationYear ?? "—"}</td>
+                  <td>
+                    <div className="application-table__committees">
+                      {[
+                        { id: app.firstChoiceCommittee, rank: "1st" },
+                        { id: app.secondChoiceCommittee, rank: "2nd" },
+                        { id: app.thirdChoiceCommittee, rank: "3rd" },
+                      ]
+                        .filter(c => c.id)
+                        .map(c => (
+                          <span key={c.rank} className="application-table__committee">
+                            <span className="application-table__rank">{c.rank}</span>
+                            {committeeLookup.get(c.id) ?? c.id}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td>
+                    <div className="application-table__status-list">
+                      {[
+                        { rank: "1st", status: app.firstChoiceStatus },
+                        { rank: "2nd", status: app.secondChoiceStatus },
+                        { rank: "3rd", status: app.thirdChoiceStatus },
+                      ]
+                        .filter(s => s.status)
+                        .map(s => (
+                          <span key={s.rank} className="application-table__status">
+                            <span className="application-table__rank">{s.rank}</span>
+                            {s.status}
+                          </span>
+                        ))}
+                    </div>
+                  </td>
+                  <td>{formatDate(app.submittedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {pagination.pages > 1 && (
+            <div className="application-table-wrapper__pagination">
+              <button
+                type="button"
+                disabled={page <= 1}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+              >
+                Previous
+              </button>
+              <span>
+                Page {pagination.page} of {pagination.pages}
+              </span>
+              <button
+                type="button"
+                disabled={page >= pagination.pages}
+                onClick={() => setPage(p => Math.min(pagination.pages, p + 1))}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/Internship/ApplicationWizard/Step1Committees/RankedList.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/RankedList.jsx
@@ -61,7 +61,7 @@ function SortableRow({ id, rank, committeeName, onRemove }) {
   );
 }
 
-export default function RankedList({ selectedCommitteeIds, onReorder, onRemove }) {
+export default function RankedList({ selectedCommitteeIds, resolvedNames, onReorder, onRemove }) {
   const committees = useAtomValue(committeesAtom);
 
   const sensors = useSensors(
@@ -78,8 +78,9 @@ export default function RankedList({ selectedCommitteeIds, onReorder, onRemove }
   }
 
   const lookupName = id => {
-    const match = committees ? committees.find(c => c.id === id) : null;
-    return match ? match.displayName : id;
+    const match = committees ? committees.find(c => c.id === id || String(c._id) === id) : null;
+    if (match) return match.displayName;
+    return resolvedNames?.[id] ?? id;
   };
 
   const handleDragEnd = event => {

--- a/components/Internship/ApplicationWizard/Step1Committees/index.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/index.jsx
@@ -10,6 +10,7 @@ import RankedList from "./RankedList";
 import useStep1Save from "./useStep1Save";
 import { authUserProfileAtom, committeesAtom, myApplicationAtom } from "@/lib/atoms";
 import fetchActiveCommittees from "@/app/actions/internship/fetchActiveCommittees";
+import useResolvedCommitteeNames from "@/lib/hooks/useResolvedCommitteeNames";
 
 export default function Step1Committees({ onValidityChange, flushPendingRef }) {
   const router = useRouter();
@@ -125,6 +126,11 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
     setSelectedCommitteeIds((prev) => prev.filter((id) => id !== committeeId));
   }, []);
 
+  // Selections can include a committee that's since been closed (it won't
+  // be in `committees`, which is active-only) — resolve its name separately
+  // so the ranked list doesn't fall back to showing a raw ObjectId.
+  const resolvedNames = useResolvedCommitteeNames(selectedCommitteeIds, committees);
+
   return (
     <section className="space-y-6">
       <h2 className="text-xl font-semibold text-slate-900">Select your committees</h2>
@@ -170,6 +176,7 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
 
       <RankedList
         selectedCommitteeIds={selectedCommitteeIds}
+        resolvedNames={resolvedNames}
         onReorder={handleReorder}
         onRemove={handleRemove}
       />

--- a/components/Internship/ApplicationWizard/Step1Committees/index.jsx
+++ b/components/Internship/ApplicationWizard/Step1Committees/index.jsx
@@ -51,10 +51,12 @@ export default function Step1Committees({ onValidityChange, flushPendingRef }) {
     }
   }, [setCommittees]);
 
+  // Always fetch fresh on mount rather than reusing whatever's already in
+  // committeesAtom — a committee's active status can change in the admin
+  // panel at any time, and this atom is shared across the wizard steps, so
+  // treating a non-empty atom as "already loaded" risks a stale snapshot.
   useEffect(() => {
-    if (committees.length === 0) {
-      loadCommittees();
-    }
+    loadCommittees();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/Internship/ApplicationWizard/Step4Review/index.jsx
+++ b/components/Internship/ApplicationWizard/Step4Review/index.jsx
@@ -11,6 +11,7 @@ import {
   myApplicationAtom,
   responsesByCommitteeAtom,
 } from "@/lib/atoms";
+import useResolvedCommitteeNames, { getCommitteeDisplayName } from "@/lib/hooks/useResolvedCommitteeNames";
 
 const MIN_GRADUATION_YEAR = 2020;
 
@@ -97,23 +98,25 @@ export default function Step4Review({ onValidityChange, flushPendingRef }) {
     }
   }, [errorKind, router]);
 
-  const committeeById = useMemo(() => {
-    const map = new Map();
-    committees.forEach((committee) => { map.set(committee.id, committee); });
-    return map;
-  }, [committees]);
+  const selectedCommitteeIds = useMemo(
+    () => getSelectedCommitteeIds(myApplication),
+    [myApplication],
+  );
+
+  // A committee can close between when it was selected and this review step
+  // (e.g. once the cycle ends), dropping it out of `committees`, which is
+  // active-only. Resolve those separately so the review still shows a real
+  // name instead of falling back to "Committee".
+  const resolvedNames = useResolvedCommitteeNames(selectedCommitteeIds, committees);
 
   const rankedCommittees = useMemo(() => (
-    getSelectedCommitteeIds(myApplication).map((committeeId, index) => {
-      const committee = committeeById.get(committeeId);
-      return {
-        committeeId,
-        rank: index + 1,
-        displayName: committee?.displayName || "Committee",
-        responses: responsesByCommittee[committeeId] || getSlotResponses(myApplication, index),
-      };
-    })
-  ), [committeeById, myApplication, responsesByCommittee]);
+    selectedCommitteeIds.map((committeeId, index) => ({
+      committeeId,
+      rank: index + 1,
+      displayName: getCommitteeDisplayName(committees, resolvedNames, committeeId) || "Committee",
+      responses: responsesByCommittee[committeeId] || getSlotResponses(myApplication, index),
+    }))
+  ), [committees, resolvedNames, selectedCommitteeIds, myApplication, responsesByCommittee]);
 
   const handleGraduationYearChange = useCallback((event) => {
     setGraduationYearInput(event.target.value);

--- a/components/Internship/CommitteeForm.jsx
+++ b/components/Internship/CommitteeForm.jsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+function toDateInputValue(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) {
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [description, setDescription] = useState(initialValues?.description ?? "");
+  const [internLimit, setInternLimit] = useState(
+    initialValues?.internLimit != null ? String(initialValues.internLimit) : "",
+  );
+  const [applicationDeadline, setApplicationDeadline] = useState(
+    toDateInputValue(initialValues?.applicationDeadline),
+  );
+  const [isActive, setIsActive] = useState(initialValues?.isActive ?? true);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const trimmedName = name.trim();
+    const payload = {
+      name: trimmedName,
+      displayName: trimmedName,
+      description: description.trim() || undefined,
+      internLimit: internLimit.trim() ? Number(internLimit) : undefined,
+      applicationDeadline: applicationDeadline || undefined,
+      isActive,
+    };
+
+    const result = await onSubmit(payload);
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error);
+    }
+  }
+
+  return (
+    <form className="committee-form" onSubmit={handleSubmit}>
+      {error && <div className="committee-form__error">{error}</div>}
+
+      <label className="committee-form__field">
+        <span className="committee-form__label">Name</span>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Hack"
+          required
+        />
+        <span className="committee-form__hint">
+          Used to match officer role assignments — keep this stable once applications exist.
+        </span>
+      </label>
+
+      <label className="committee-form__field">
+        <span className="committee-form__label">Description</span>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={4}
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--inline">
+        <span className="committee-form__label">Intern Limit</span>
+        <input
+          type="number"
+          min="0"
+          value={internLimit}
+          onChange={(e) => setInternLimit(e.target.value)}
+          placeholder="No limit"
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--inline">
+        <span className="committee-form__label">Application Deadline</span>
+        <input
+          type="date"
+          value={applicationDeadline}
+          onChange={(e) => setApplicationDeadline(e.target.value)}
+        />
+      </label>
+
+      <label className="committee-form__field committee-form__field--checkbox">
+        <input
+          type="checkbox"
+          checked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        />
+        <span>Active (accepting applications)</span>
+      </label>
+
+      <div className="committee-form__actions">
+        <button type="submit" className="committee-form__submit" disabled={submitting}>
+          {submitting ? "Saving…" : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/Internship/CommitteeForm.jsx
+++ b/components/Internship/CommitteeForm.jsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import useCustomQuestionsEditor from "@/lib/hooks/useCustomQuestionsEditor";
+import CustomQuestionsEditor from "./CustomQuestionsEditor";
 
 function toDateInputValue(value) {
   if (!value) return "";
@@ -19,6 +21,7 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
     toDateInputValue(initialValues?.applicationDeadline),
   );
   const [isActive, setIsActive] = useState(initialValues?.isActive ?? true);
+  const questionsEditor = useCustomQuestionsEditor(initialValues?.customQuestions);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -28,6 +31,11 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
 
     if (!name.trim()) {
       setError("Name is required.");
+      return;
+    }
+    const questionsError = questionsEditor.validate();
+    if (questionsError) {
+      setError(questionsError);
       return;
     }
 
@@ -42,6 +50,7 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
       internLimit: internLimit.trim() ? Number(internLimit) : undefined,
       applicationDeadline: applicationDeadline || undefined,
       isActive,
+      customQuestions: questionsEditor.toPayload(),
     };
 
     const result = await onSubmit(payload);
@@ -78,6 +87,8 @@ export default function CommitteeForm({ initialValues, submitLabel, onSubmit }) 
           rows={4}
         />
       </label>
+
+      <CustomQuestionsEditor editor={questionsEditor} />
 
       <label className="committee-form__field committee-form__field--inline">
         <span className="committee-form__label">Intern Limit</span>

--- a/components/Internship/CommitteeQuestionsModal.jsx
+++ b/components/Internship/CommitteeQuestionsModal.jsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import useCustomQuestionsEditor from "@/lib/hooks/useCustomQuestionsEditor";
+import CustomQuestionsEditor from "./CustomQuestionsEditor";
+import updateCommitteeQuestions from "@/app/actions/internship/updateCommitteeQuestions";
+import "@/components/Internship/AdminDashboard.scss";
+import "./CommitteeQuestionsModal.scss";
+
+export default function CommitteeQuestionsModal({ committee, onClose, onSaved }) {
+  const questionsEditor = useCustomQuestionsEditor(committee.customQuestions);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function handleSave() {
+    const validationError = questionsEditor.validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    const result = await updateCommitteeQuestions(committee.id, questionsEditor.toPayload());
+    setSubmitting(false);
+
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+
+    onSaved(result.data);
+  }
+
+  return (
+    <div className="committee-questions-modal-wrapper">
+      <div className="committee-questions-modal">
+        <div className="committee-questions-modal__header">
+          <h3>Edit {committee.displayName} Questions</h3>
+          <button
+            type="button"
+            className="committee-questions-modal__close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="committee-questions-modal__body">
+          {error && <div className="committee-form__error">{error}</div>}
+          <CustomQuestionsEditor editor={questionsEditor} />
+        </div>
+
+        <div className="committee-questions-modal__footer">
+          <button
+            type="button"
+            className="committee-questions-modal__cancel"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="committee-form__submit"
+            onClick={handleSave}
+            disabled={submitting}
+          >
+            {submitting ? "Saving…" : "Save Questions"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Internship/CommitteeQuestionsModal.scss
+++ b/components/Internship/CommitteeQuestionsModal.scss
@@ -1,0 +1,82 @@
+@use "@/styles/vars";
+
+.committee-questions-modal-wrapper {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  padding: 1.5rem;
+}
+
+.committee-questions-modal {
+  background: vars.$white;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 640px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid vars.$gray1;
+
+    h3 {
+      margin: 0;
+      font-size: 1.1rem;
+    }
+  }
+
+  &__close {
+    appearance: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.3rem;
+    line-height: 1;
+    color: vars.$gray3;
+
+    &:hover {
+      color: vars.$dark-red;
+    }
+  }
+
+  &__body {
+    padding: 1.5rem;
+    overflow-y: auto;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+    border-top: 1px solid vars.$gray1;
+  }
+
+  &__cancel {
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$gray1;
+    border-radius: 4px;
+    padding: 0.6rem 1.25rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+
+    &:hover:not(:disabled) {
+      border-color: vars.$gray3;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/components/Internship/CommitteeTable.jsx
+++ b/components/Internship/CommitteeTable.jsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import BulkActionBar from "@/components/Internship/BulkActionBar";
+import ConfirmationModal from "@/components/Modal/confirmationModal";
 import bulkUpdateCommitteeStatus from "@/app/actions/internship/bulkUpdateCommitteeStatus";
+import deleteCommittee from "@/app/actions/internship/deleteCommittee";
+import fetchApplicationCycle from "@/app/actions/internship/fetchApplicationCycle";
+import advanceApplicationCycle from "@/app/actions/internship/advanceApplicationCycle";
 
 function formatDeadline(value) {
   if (!value) return "—";
@@ -12,14 +16,130 @@ function formatDeadline(value) {
   return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
+function CycleControls({ onAdvanced }) {
+  const [expanded, setExpanded] = useState(false);
+  const [info, setInfo] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [newCycle, setNewCycle] = useState("");
+  const [confirming, setConfirming] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    if (!expanded || info) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      const result = await fetchApplicationCycle();
+      if (cancelled) return;
+      setLoading(false);
+      if (result.success) {
+        setInfo(result.data);
+        setNewCycle(result.data.suggestedNextCycle);
+      } else {
+        setError(result.error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded, info]);
+
+  async function handleConfirmAdvance() {
+    setConfirming(false);
+    setPending(true);
+    setError(null);
+    const result = await advanceApplicationCycle(newCycle);
+    setPending(false);
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    setExpanded(false);
+    setInfo(null);
+    onAdvanced?.(result);
+  }
+
+  return (
+    <div className="cycle-controls">
+      <button
+        type="button"
+        className="committee-table-wrapper__bulk-btn committee-table-wrapper__bulk-btn--warning"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        Start New Application Cycle
+      </button>
+
+      {expanded && (
+        <div className="cycle-controls__panel">
+          {loading && <div className="cycle-controls__loading">Loading cycle info…</div>}
+          {error && <div className="committee-table-wrapper__error">{error}</div>}
+          {info && (
+            <>
+              <div className="cycle-controls__current">
+                Current cycle: <strong>{info.currentCycle}</strong>
+              </div>
+              <label className="cycle-controls__field">
+                <span>New cycle label</span>
+                <input
+                  type="text"
+                  value={newCycle}
+                  onChange={(e) => setNewCycle(e.target.value)}
+                />
+              </label>
+              <p className="cycle-controls__warning">
+                This archives every committee&apos;s current-cycle applications and makes the
+                cycle above the new current cycle. Applications remain accessible in the
+                past-cycles view.
+              </p>
+              <div className="cycle-controls__actions">
+                <button
+                  type="button"
+                  className="committee-form__danger-btn committee-form__danger-btn--delete"
+                  disabled={pending || !newCycle.trim()}
+                  onClick={() => setConfirming(true)}
+                >
+                  {pending ? "Advancing…" : "Advance Cycle"}
+                </button>
+                <button
+                  type="button"
+                  className="committee-table-wrapper__bulk-btn"
+                  onClick={() => setExpanded(false)}
+                  disabled={pending}
+                >
+                  Cancel
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <ConfirmationModal
+        opened={confirming}
+        title="Start a new application cycle?"
+        message={`This archives every committee's current-cycle applications and sets "${newCycle}" as the new current cycle. This cannot be undone from the UI.`}
+        submit={handleConfirmAdvance}
+        cancel={() => setConfirming(false)}
+      />
+    </div>
+  );
+}
+
 export default function CommitteeTable({ committees, onMutated }) {
   const [selected, setSelected] = useState(() => new Set());
   const [pending, setPending] = useState(false);
   const [error, setError] = useState(null);
+  const [deleteTargetId, setDeleteTargetId] = useState(null);
+  const [cycleNotice, setCycleNotice] = useState(null);
 
   const allIds = useMemo(() => committees.map(c => c.id), [committees]);
   const allChecked = allIds.length > 0 && selected.size === allIds.length;
   const someChecked = selected.size > 0 && !allChecked;
+  const deleteTarget = useMemo(
+    () => committees.find(c => c.id === deleteTargetId) ?? null,
+    [committees, deleteTargetId],
+  );
 
   function toggle(id) {
     setSelected(prev => {
@@ -51,6 +171,20 @@ export default function CommitteeTable({ committees, onMutated }) {
     onMutated?.();
   }
 
+  async function handleConfirmDelete() {
+    const id = deleteTargetId;
+    setDeleteTargetId(null);
+    setPending(true);
+    setError(null);
+    const result = await deleteCommittee(id);
+    setPending(false);
+    if (!result.success) {
+      setError(result.error);
+      return;
+    }
+    onMutated?.();
+  }
+
   return (
     <div className="committee-table-wrapper">
       <div className="committee-table-wrapper__header">
@@ -72,12 +206,21 @@ export default function CommitteeTable({ committees, onMutated }) {
           >
             Close All
           </button>
+          <CycleControls
+            onAdvanced={(result) => {
+              setCycleNotice(
+                `Advanced to cycle ${result.newCycle}. Archived ${result.archivedCount} application${result.archivedCount === 1 ? "" : "s"}.`,
+              );
+              onMutated?.();
+            }}
+          />
           <Link href="/internship/admin/committees/new" className="committee-table__edit-link">
             + Create Committee
           </Link>
         </div>
       </div>
 
+      {cycleNotice && <div className="cycle-controls__notice">{cycleNotice}</div>}
       {error && <div className="committee-table-wrapper__error">{error}</div>}
 
       {selected.size > 0 && (
@@ -142,18 +285,36 @@ export default function CommitteeTable({ committees, onMutated }) {
                 <td>{c.internLimit ?? "—"}</td>
                 <td>{c.applicationCount ?? 0}</td>
                 <td>
-                  <Link
-                    href={`/internship/admin/committees/${c.id}/edit`}
-                    className="committee-table__edit-link"
-                  >
-                    Edit
-                  </Link>
+                  <div className="committee-table__row-actions">
+                    <Link
+                      href={`/internship/admin/committees/${c.id}/edit`}
+                      className="committee-table__edit-link"
+                    >
+                      Edit
+                    </Link>
+                    <button
+                      type="button"
+                      className="committee-table__delete-link"
+                      disabled={pending}
+                      onClick={() => setDeleteTargetId(c.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
+
+      <ConfirmationModal
+        opened={deleteTargetId !== null}
+        title="Delete this committee?"
+        message={`This deactivates "${deleteTarget?.displayName ?? ""}" — it stops accepting applications and disappears from active lists. This can be undone by reactivating it later.`}
+        submit={handleConfirmDelete}
+        cancel={() => setDeleteTargetId(null)}
+      />
     </div>
   );
 }

--- a/components/Internship/CustomQuestionsEditor.jsx
+++ b/components/Internship/CustomQuestionsEditor.jsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+
+const QUESTION_TYPES = [
+  { value: "short_text", label: "Short text" },
+  { value: "long_text", label: "Long text" },
+  { value: "multiple_choice", label: "Multiple choice" },
+];
+
+function QuestionChoices({ choices, onAdd, onRemove }) {
+  const [input, setInput] = useState("");
+
+  function commit() {
+    const trimmed = input.trim();
+    if (trimmed) onAdd(trimmed);
+    setInput("");
+  }
+
+  return (
+    <div className="committee-form__choices">
+      <div className="committee-form__choice-input">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          placeholder="Add a choice and press Enter"
+        />
+        <button type="button" onClick={commit}>
+          Add
+        </button>
+      </div>
+      {choices.length > 0 && (
+        <div className="committee-form__choice-tags">
+          {choices.map((choice) => (
+            <span key={choice} className="committee-form__choice-tag">
+              {choice}
+              <button type="button" aria-label={`Remove ${choice}`} onClick={() => onRemove(choice)}>
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Renders the add/edit/reorder UI for a committee's customQuestions, driven
+// by the state + handlers from useCustomQuestionsEditor. Shared between the
+// admin committee form and the officer's questions-only editor.
+export default function CustomQuestionsEditor({ editor }) {
+  const {
+    questions,
+    addQuestion,
+    updateQuestion,
+    handleQuestionTextChange,
+    handleQuestionKeyChange,
+    removeQuestion,
+    moveQuestion,
+    addChoice,
+    removeChoice,
+  } = editor;
+
+  return (
+    <div className="committee-form__field">
+      <div className="committee-form__questions-header">
+        <span className="committee-form__label">Custom Questions</span>
+        <button type="button" className="committee-form__question-add" onClick={addQuestion}>
+          Add Question
+        </button>
+      </div>
+
+      {questions.length === 0 && (
+        <span className="committee-form__hint">No custom questions yet.</span>
+      )}
+
+      {questions.map((question, index) => (
+        <div key={question.clientId} className="committee-form__question">
+          <div className="committee-form__question-row">
+            <span className="committee-form__question-index">{index + 1}.</span>
+            <input
+              type="text"
+              value={question.questionText}
+              onChange={(e) => handleQuestionTextChange(question.clientId, e.target.value)}
+              placeholder="Question text"
+              className="committee-form__question-text"
+              required
+            />
+            <button
+              type="button"
+              onClick={() => moveQuestion(question.clientId, -1)}
+              disabled={index === 0}
+              aria-label="Move question up"
+            >
+              ↑
+            </button>
+            <button
+              type="button"
+              onClick={() => moveQuestion(question.clientId, 1)}
+              disabled={index === questions.length - 1}
+              aria-label="Move question down"
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              className="committee-form__question-remove"
+              aria-label="Remove question"
+              onClick={() => removeQuestion(question.clientId)}
+            >
+              ×
+            </button>
+          </div>
+
+          <div className="committee-form__question-row committee-form__question-row--meta">
+            <label className="committee-form__question-key">
+              <span>Key</span>
+              <input
+                type="text"
+                value={question.questionKey}
+                onChange={(e) => handleQuestionKeyChange(question.clientId, e.target.value)}
+                placeholder="auto-generated"
+                required
+              />
+            </label>
+
+            <label className="committee-form__question-type">
+              <span>Type</span>
+              <select
+                value={question.questionType}
+                onChange={(e) => updateQuestion(question.clientId, { questionType: e.target.value })}
+              >
+                {QUESTION_TYPES.map((type) => (
+                  <option key={type.value} value={type.value}>{type.label}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="committee-form__question-required">
+              <input
+                type="checkbox"
+                checked={question.required}
+                onChange={(e) => updateQuestion(question.clientId, { required: e.target.checked })}
+              />
+              <span>Required</span>
+            </label>
+          </div>
+
+          {question.questionType === "multiple_choice" && (
+            <QuestionChoices
+              choices={question.choices}
+              onAdd={(choice) => addChoice(question.clientId, choice)}
+              onRemove={(choice) => removeChoice(question.clientId, choice)}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/Internship/CycleStatusBanner.jsx
+++ b/components/Internship/CycleStatusBanner.jsx
@@ -11,8 +11,11 @@ export default function CycleStatusBanner() {
   const setActiveCommittees = useSetAtom(activeCommitteesAtom);
   const hasRequestedRef = useRef(false);
 
+  // Always fetch fresh on mount rather than skipping when activeCommitteesAtom
+  // is already populated — it's shared across components/pages, so treating
+  // it as "already loaded" risks showing a stale snapshot from earlier in
+  // the session (e.g. after an admin opens/closes committees elsewhere).
   useEffect(() => {
-    if (activeCommittees !== null) return;
     if (hasRequestedRef.current) return;
     hasRequestedRef.current = true;
 
@@ -34,7 +37,7 @@ export default function CycleStatusBanner() {
     return () => {
       cancelled = true;
     };
-  }, [activeCommittees, setActiveCommittees]);
+  }, [setActiveCommittees]);
 
   if (activeCommittees === null) return null;
 

--- a/components/Internship/MemberDashboard.jsx
+++ b/components/Internship/MemberDashboard.jsx
@@ -31,9 +31,11 @@ export default function MemberDashboard() {
 
       try {
         const applicationPromise = fetchOwnApplication();
-        const committeesPromise = activeCommittees === null
-          ? fetchAllCommittees()
-          : Promise.resolve({ success: true, data: activeCommittees });
+        // Always fetch fresh — a committee's active status can change in the
+        // admin panel at any time, and activeCommitteesAtom is shared across
+        // components/pages, so reusing whatever's already in it risks
+        // showing a stale snapshot from earlier in the session.
+        const committeesPromise = fetchAllCommittees();
 
         const [applicationResult, committeesResult] = await Promise.all([
           applicationPromise,

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -14,6 +14,7 @@ import OfficerStatsBar from "@/app/internship/components/OfficerStatsBar";
 import Toast from "@/components/Toast";
 import useDebouncedValue from "@/lib/hooks/useDebouncedValue";
 import { authUserProfileAtom, officerApplicationsAtom } from "@/lib/atoms";
+import CommitteeQuestionsModal from "./CommitteeQuestionsModal";
 import "./OfficerDashboard.scss";
 
 const CHOICE_FIELDS = [
@@ -111,6 +112,7 @@ export default function OfficerDashboard() {
   const [page, setPage] = useState(1);
 
   const [selectedApplicationId, setSelectedApplicationId] = useState(null);
+  const [isQuestionsModalOpen, setIsQuestionsModalOpen] = useState(false);
   const [toast, setToast] = useState({ key: 0, message: "", success: true, visible: false });
 
   const showToast = useCallback((message, success) => {
@@ -256,6 +258,14 @@ export default function OfficerDashboard() {
     loadStatusCounts();
   }, [setApplications, loadStatusCounts]);
 
+  const handleQuestionsSaved = useCallback((updatedCommittee) => {
+    setCommittees((prev) => prev.map((committee) => (
+      committee.id === updatedCommittee.id ? { ...committee, ...updatedCommittee } : committee
+    )));
+    setIsQuestionsModalOpen(false);
+    showToast("Committee questions saved", true);
+  }, [showToast]);
+
   // Walks every server page under the current filters (the on-screen list is
   // only one page of up to PAGE_SIZE) so "copy emails" grabs every matching
   // applicant's email, not just whichever page happens to be displayed.
@@ -328,6 +338,13 @@ export default function OfficerDashboard() {
       <div className="officer-dashboard__header">
         <h2>{myCommittee.displayName}</h2>
         <span className="officer-dashboard__cycle">Cycle {recruitmentCycle}</span>
+        <button
+          type="button"
+          className="officer-dashboard__edit-questions"
+          onClick={() => setIsQuestionsModalOpen(true)}
+        >
+          Edit Questions
+        </button>
       </div>
 
       <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={handleSelectStatus} />
@@ -388,6 +405,14 @@ export default function OfficerDashboard() {
       />
 
       <Toast key={toast.key} showing={toast.visible} message={toast.message} success={toast.success} />
+
+      {isQuestionsModalOpen && (
+        <CommitteeQuestionsModal
+          committee={myCommittee}
+          onClose={() => setIsQuestionsModalOpen(false)}
+          onSaved={handleQuestionsSaved}
+        />
+      )}
     </div>
   );
 }

--- a/components/Internship/OfficerDashboard.jsx
+++ b/components/Internship/OfficerDashboard.jsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAtom, useAtomValue } from "jotai";
 
 import fetchAllApplications from "@/app/actions/internship/fetchAllApplications";
 import fetchAllCommittees from "@/app/actions/internship/fetchAllCommittees";
+import fetchApplicationStatusCounts from "@/app/actions/internship/fetchApplicationStatusCounts";
 import ApplicationDetailDrawer from "@/app/internship/components/ApplicationDetailDrawer";
 import ApplicationTable from "@/app/internship/components/ApplicationTable";
 import CopyEmailsButton from "@/app/internship/components/CopyEmailsButton";
@@ -53,6 +54,8 @@ const EMPTY_STATUS_COUNTS = {
   rejected: 0,
 };
 
+const PAGE_SIZE = 25;
+
 function getCurrentApplicationCycle() {
   const year = new Date().getFullYear();
   return `${year}-${year + 1}`;
@@ -91,14 +94,21 @@ export default function OfficerDashboard() {
   );
 
   const [committees, setCommittees] = useState([]);
+  const [committeesStatus, setCommitteesStatus] = useState("loading");
+  const [committeesError, setCommitteesError] = useState(null);
+
   const [applications, setApplications] = useAtom(officerApplicationsAtom);
+  const [pagination, setPagination] = useState({ page: 1, limit: PAGE_SIZE, total: 0, pages: 0 });
   const [loadStatus, setLoadStatus] = useState("loading");
   const [loadError, setLoadError] = useState(null);
+
+  const [statusCounts, setStatusCounts] = useState(EMPTY_STATUS_COUNTS);
 
   const [statusFilter, setStatusFilter] = useState("all");
   const [choiceFilter, setChoiceFilter] = useState("all");
   const [searchInput, setSearchInput] = useState("");
   const debouncedSearch = useDebouncedValue(searchInput, 300);
+  const [page, setPage] = useState(1);
 
   const [selectedApplicationId, setSelectedApplicationId] = useState(null);
   const [toast, setToast] = useState({ key: 0, message: "", success: true, visible: false });
@@ -120,82 +130,118 @@ export default function OfficerDashboard() {
 
   useEffect(() => {
     let cancelled = false;
+    (async () => {
+      setCommitteesStatus("loading");
+      const result = await fetchAllCommittees();
+      if (cancelled) return;
+      if (result.success) {
+        setCommittees(result.data);
+        setCommitteesError(null);
+        setCommitteesStatus("success");
+      } else {
+        setCommitteesError(result.error);
+        setCommitteesStatus("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
-    async function load() {
+  const myCommittee = committees.find((committee) => (
+    normalizeCommitteeName(committee.displayName) === officerCommitteeName
+    || normalizeCommitteeName(committee.name) === officerCommitteeName
+  )) ?? null;
+
+  // Used both for the initial/dependency-driven fetch below and as a manual
+  // re-trigger from handleApplicationChanged (a status edit shifts counts).
+  const loadStatusCounts = useCallback(async () => {
+    if (!myCommittee) return;
+    const result = await fetchApplicationStatusCounts(myCommittee.id);
+    if (result.success) {
+      setStatusCounts({ ...EMPTY_STATUS_COUNTS, ...result.counts });
+    }
+  }, [myCommittee]);
+
+  useEffect(() => {
+    if (!myCommittee) return undefined;
+    let cancelled = false;
+    (async () => {
+      const result = await fetchApplicationStatusCounts(myCommittee.id);
+      if (cancelled || !result.success) return;
+      setStatusCounts({ ...EMPTY_STATUS_COUNTS, ...result.counts });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [myCommittee]);
+
+  // Filter changes reset pagination back to page 1 — done directly in each
+  // handler (below) rather than via a useEffect watching the filter values,
+  // since that would just be an extra render-effect-render round trip for a
+  // state update that's already known at the moment the filter changes.
+  function handleStatusFilterChange(nextStatus) {
+    setStatusFilter(nextStatus);
+    setPage(1);
+  }
+
+  function handleChoiceFilterChange(nextChoice) {
+    setChoiceFilter(nextChoice);
+    setPage(1);
+  }
+
+  function handleSearchInputChange(nextSearch) {
+    setSearchInput(nextSearch);
+    setPage(1);
+  }
+
+  // Deliberately does NOT wait on committees/myCommittee — the backend
+  // already scopes an officer's applications to their own committee via
+  // their JWT, so this request doesn't need committee data first. Gating it
+  // on myCommittee would serialize two independent network round trips
+  // (committees, then applications) instead of firing them in parallel.
+  // myCommittee is only needed for client-side enrichment, which happens
+  // reactively below once both have loaded.
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
       setLoadStatus("loading");
-      const [committeesResult, applicationsResult] = await Promise.all([
-        fetchAllCommittees(),
-        fetchAllApplications(),
-      ]);
-
+      const result = await fetchAllApplications({
+        page,
+        limit: PAGE_SIZE,
+        search: debouncedSearch.trim() || undefined,
+        status: statusFilter !== "all" ? statusFilter : undefined,
+        choiceRank: choiceFilter !== "all" ? choiceFilter : undefined,
+      });
       if (cancelled) return;
 
-      if (!committeesResult.success) {
-        setLoadError(committeesResult.error);
-        setLoadStatus("error");
-        return;
-      }
-      if (!applicationsResult.success) {
-        setLoadError(applicationsResult.error);
+      if (!result.success) {
+        setLoadError(result.error);
         setLoadStatus("error");
         return;
       }
 
-      setCommittees(committeesResult.data);
-      setApplications(applicationsResult.data);
+      setApplications(result.data);
+      setPagination(result.pagination);
       setLoadError(null);
       setLoadStatus("success");
-    }
-
-    load();
+    })();
 
     return () => {
       cancelled = true;
     };
-  }, [setApplications]);
+  }, [page, debouncedSearch, statusFilter, choiceFilter, setApplications]);
 
-  const myCommittee = useMemo(() => committees.find((committee) => (
-    normalizeCommitteeName(committee.displayName) === officerCommitteeName
-    || normalizeCommitteeName(committee.name) === officerCommitteeName
-  )), [committees, officerCommitteeName]);
+  const enrichedApplications = myCommittee
+    ? applications.map((application) => enrichForCommittee(application, myCommittee.id)).filter(Boolean)
+    : [];
 
   const recruitmentCycle = applications[0]?.applicationCycle ?? getCurrentApplicationCycle();
 
-  // Recomputed only when the raw application list or the officer's committee
-  // changes — filtering below runs against this instead of re-deriving
-  // rank/status/responses on every keystroke or filter change.
-  const enrichedApplications = useMemo(() => {
-    if (!myCommittee) return [];
-    return applications
-      .map((application) => enrichForCommittee(application, myCommittee.id))
-      .filter(Boolean);
-  }, [applications, myCommittee]);
-
-  const statusCounts = useMemo(() => {
-    const counts = { ...EMPTY_STATUS_COUNTS };
-    enrichedApplications.forEach((application) => {
-      if (application.myStatus in counts) counts[application.myStatus] += 1;
-    });
-    return counts;
-  }, [enrichedApplications]);
-
-  const filteredApplications = useMemo(() => {
-    const term = debouncedSearch.trim().toLowerCase();
-    return enrichedApplications.filter((application) => {
-      if (statusFilter !== "all" && application.myStatus !== statusFilter) return false;
-      if (choiceFilter !== "all" && String(application.myChoiceRank) !== choiceFilter) return false;
-      if (term) {
-        const haystack = `${application.firstName ?? ""} ${application.lastName ?? ""} ${application.email ?? ""}`.toLowerCase();
-        if (!haystack.includes(term)) return false;
-      }
-      return true;
-    });
-  }, [enrichedApplications, statusFilter, choiceFilter, debouncedSearch]);
-
-  const selectedApplication = useMemo(
-    () => enrichedApplications.find((application) => application._id === selectedApplicationId) ?? null,
-    [enrichedApplications, selectedApplicationId],
-  );
+  const selectedApplication = enrichedApplications.find(
+    (application) => application._id === selectedApplicationId,
+  ) ?? null;
 
   // Writes through the shared atom, so the table and the drawer — both
   // reading from the same atom — reflect a status/rating/notes change
@@ -204,7 +250,38 @@ export default function OfficerDashboard() {
     setApplications((prev) => prev.map((application) => (
       application._id === applicationId ? { ...application, ...updatedApplication } : application
     )));
-  }, [setApplications]);
+    // A status change shifts the stats-pill counts; refetch rather than
+    // trying to patch counts locally (rating/notes changes don't affect
+    // counts, but this stays correct for all mutation types either way).
+    loadStatusCounts();
+  }, [setApplications, loadStatusCounts]);
+
+  // Walks every server page under the current filters (the on-screen list is
+  // only one page of up to PAGE_SIZE) so "copy emails" grabs every matching
+  // applicant's email, not just whichever page happens to be displayed.
+  const handleFetchAllEmails = useCallback(async () => {
+    const emails = [];
+    const fetchOptions = {
+      limit: 100,
+      search: debouncedSearch.trim() || undefined,
+      status: statusFilter !== "all" ? statusFilter : undefined,
+      choiceRank: choiceFilter !== "all" ? choiceFilter : undefined,
+    };
+
+    let currentPage = 1;
+    let totalPages = 1;
+    do {
+      const result = await fetchAllApplications({ ...fetchOptions, page: currentPage });
+      if (!result.success) throw new Error(result.error);
+      result.data.forEach((application) => {
+        if (application.email) emails.push(application.email);
+      });
+      totalPages = result.pagination.pages;
+      currentPage += 1;
+    } while (currentPage <= totalPages);
+
+    return emails;
+  }, [debouncedSearch, statusFilter, choiceFilter]);
 
   const handleCopied = useCallback((count) => {
     showToast(`Copied ${count} email address${count === 1 ? "" : "es"}`, true);
@@ -214,8 +291,16 @@ export default function OfficerDashboard() {
     showToast(message, false);
   }, [showToast]);
 
-  if (loadStatus === "loading") {
+  function handleSelectStatus(nextStatus) {
+    handleStatusFilterChange(nextStatus);
+  }
+
+  if (committeesStatus === "loading" || (committeesStatus === "success" && loadStatus === "loading" && applications.length === 0)) {
     return <div className="officer-dashboard officer-dashboard__placeholder">Loading applications…</div>;
+  }
+
+  if (committeesStatus === "error") {
+    return <div className="officer-dashboard officer-dashboard__error">{committeesError}</div>;
   }
 
   if (loadStatus === "error") {
@@ -245,33 +330,56 @@ export default function OfficerDashboard() {
         <span className="officer-dashboard__cycle">Cycle {recruitmentCycle}</span>
       </div>
 
-      <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={setStatusFilter} />
+      <OfficerStatsBar counts={statusCounts} activeStatus={statusFilter} onSelectStatus={handleSelectStatus} />
 
       <OfficerFilterBar
         statusFilter={statusFilter}
-        onStatusFilterChange={setStatusFilter}
+        onStatusFilterChange={handleStatusFilterChange}
         choiceFilter={choiceFilter}
-        onChoiceFilterChange={setChoiceFilter}
+        onChoiceFilterChange={handleChoiceFilterChange}
         searchInput={searchInput}
-        onSearchInputChange={setSearchInput}
+        onSearchInputChange={handleSearchInputChange}
       />
 
       <div className="officer-dashboard__toolbar">
         <div className="officer-dashboard__count">
-          {filteredApplications.length} of {enrichedApplications.length} applications
+          {pagination.total} application{pagination.total === 1 ? "" : "s"}
         </div>
         <CopyEmailsButton
-          applications={filteredApplications}
+          totalCount={pagination.total}
+          onFetchAllEmails={handleFetchAllEmails}
           onCopied={handleCopied}
           onError={handleCopyError}
         />
       </div>
 
       <ApplicationTable
-        applications={filteredApplications}
+        applications={enrichedApplications}
         onApplicationChanged={handleApplicationChanged}
         onRowClick={setSelectedApplicationId}
       />
+
+      {pagination.pages > 1 && (
+        <div className="officer-dashboard__pagination">
+          <button
+            type="button"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </button>
+          <span>
+            Page {pagination.page} of {pagination.pages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= pagination.pages}
+            onClick={() => setPage((p) => Math.min(pagination.pages, p + 1))}
+          >
+            Next
+          </button>
+        </div>
+      )}
 
       <ApplicationDetailDrawer
         application={selectedApplication}

--- a/components/Internship/OfficerDashboard.scss
+++ b/components/Internship/OfficerDashboard.scss
@@ -22,6 +22,23 @@
     font-weight: 500;
   }
 
+  &__edit-questions {
+    margin-left: auto;
+    appearance: none;
+    background: vars.$white;
+    border: 1px solid vars.$primary-color;
+    color: vars.$primary-color;
+    border-radius: 4px;
+    padding: 0.45rem 0.9rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+
+    &:hover {
+      background: vars.$primary-color;
+      color: vars.$white;
+    }
+  }
+
   &__placeholder,
   &__error {
     padding: 2rem;

--- a/components/Internship/OfficerDashboard.scss
+++ b/components/Internship/OfficerDashboard.scss
@@ -45,6 +45,36 @@
     gap: 1rem;
     margin-bottom: 0.75rem;
   }
+
+  &__pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 1rem;
+    font-size: 0.85rem;
+    color: vars.$gray3;
+
+    button {
+      appearance: none;
+      background: vars.$white;
+      border: 1px solid vars.$gray1;
+      border-radius: 4px;
+      padding: 0.4rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+
+      &:hover:not(:disabled) {
+        border-color: vars.$primary-color;
+        color: vars.$primary-color;
+      }
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+  }
 }
 
 .copy-emails-button {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,10 +36,13 @@ const config = {
     },
     internship: {
       applications: "/api/v1/internship/applications",
+      applicationStatusCounts: "/api/v1/internship/applications/status-counts",
       ownApplication: "/api/v1/internship/applications/me",
       committees: "/api/v1/internship/committees",
       committeesAdmin: "/api/v1/internship/committees/admin",
       committeesBulkStatus: "/api/v1/internship/committees/bulk-status",
+      cycle: "/api/v1/internship/cycle",
+      cycleAdvance: "/api/v1/internship/cycle/advance",
     },
     leaderboard: "/api/v1/leaderboard",
     leaderboardAdmin: "/api/v1/leaderboard/admin",

--- a/lib/hooks/useCustomQuestionsEditor.js
+++ b/lib/hooks/useCustomQuestionsEditor.js
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+
+let clientIdCounter = 0;
+function makeClientId() {
+  clientIdCounter += 1;
+  return `q-${clientIdCounter}`;
+}
+
+function slugify(text) {
+  return text.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function uniqueKey(base, takenKeys) {
+  const root = base || "question";
+  if (!takenKeys.has(root)) return root;
+  let i = 2;
+  while (takenKeys.has(`${root}_${i}`)) i += 1;
+  return `${root}_${i}`;
+}
+
+// Shared editing state/logic for a committee's customQuestions array — used
+// by the admin committee form (full committee edit) and the officer's
+// questions-only editor (PUT /committees/:id/questions), so both stay in
+// sync on validation, key auto-generation, and payload shape.
+export default function useCustomQuestionsEditor(initialQuestions) {
+  const [questions, setQuestions] = useState(() => (
+    (initialQuestions ?? []).map((q) => ({
+      clientId: makeClientId(),
+      questionKey: q.questionKey ?? "",
+      questionText: q.questionText ?? "",
+      questionType: q.questionType ?? "short_text",
+      required: q.required ?? true,
+      choices: Array.isArray(q.choices) ? q.choices : [],
+      // Existing questions keep their key stable even if the text is edited —
+      // applicant responses are stored against questionKey, so changing it
+      // on an edit would orphan any answers already saved against it.
+      keyTouched: true,
+    }))
+  ));
+
+  function addQuestion() {
+    setQuestions((prev) => [
+      ...prev,
+      {
+        clientId: makeClientId(),
+        questionKey: "",
+        questionText: "",
+        questionType: "short_text",
+        required: true,
+        choices: [],
+        keyTouched: false,
+      },
+    ]);
+  }
+
+  function updateQuestion(clientId, patch) {
+    setQuestions((prev) => prev.map((q) => (q.clientId === clientId ? { ...q, ...patch } : q)));
+  }
+
+  function handleQuestionTextChange(clientId, text) {
+    setQuestions((prev) => prev.map((q) => {
+      if (q.clientId !== clientId) return q;
+      if (q.keyTouched) return { ...q, questionText: text };
+      const takenKeys = new Set(
+        prev.filter((other) => other.clientId !== clientId).map((other) => other.questionKey),
+      );
+      return { ...q, questionText: text, questionKey: uniqueKey(slugify(text), takenKeys) };
+    }));
+  }
+
+  function handleQuestionKeyChange(clientId, key) {
+    updateQuestion(clientId, { questionKey: key, keyTouched: true });
+  }
+
+  function removeQuestion(clientId) {
+    setQuestions((prev) => prev.filter((q) => q.clientId !== clientId));
+  }
+
+  function moveQuestion(clientId, direction) {
+    setQuestions((prev) => {
+      const idx = prev.findIndex((q) => q.clientId === clientId);
+      const swapWith = idx + direction;
+      if (idx === -1 || swapWith < 0 || swapWith >= prev.length) return prev;
+      const next = [...prev];
+      [next[idx], next[swapWith]] = [next[swapWith], next[idx]];
+      return next;
+    });
+  }
+
+  function addChoice(clientId, choiceText) {
+    setQuestions((prev) => prev.map((q) => (
+      q.clientId === clientId && !q.choices.includes(choiceText)
+        ? { ...q, choices: [...q.choices, choiceText] }
+        : q
+    )));
+  }
+
+  function removeChoice(clientId, choice) {
+    setQuestions((prev) => prev.map((q) => (
+      q.clientId === clientId ? { ...q, choices: q.choices.filter((c) => c !== choice) } : q
+    )));
+  }
+
+  function validate() {
+    if (questions.some((q) => !q.questionText.trim() || !q.questionKey.trim())) {
+      return "Every custom question needs both a key and question text.";
+    }
+    const keys = questions.map((q) => q.questionKey.trim());
+    if (new Set(keys).size !== keys.length) {
+      return "Custom question keys must be unique.";
+    }
+    return null;
+  }
+
+  function toPayload() {
+    return questions.map((q, index) => ({
+      questionKey: q.questionKey.trim(),
+      questionText: q.questionText.trim(),
+      questionType: q.questionType,
+      required: q.required,
+      order: index,
+      choices: q.questionType === "multiple_choice" ? q.choices : [],
+    }));
+  }
+
+  return {
+    questions,
+    addQuestion,
+    updateQuestion,
+    handleQuestionTextChange,
+    handleQuestionKeyChange,
+    removeQuestion,
+    moveQuestion,
+    addChoice,
+    removeChoice,
+    validate,
+    toPayload,
+  };
+}

--- a/lib/hooks/useResolvedCommitteeNames.js
+++ b/lib/hooks/useResolvedCommitteeNames.js
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import fetchCommitteeById from "@/app/actions/internship/fetchCommitteeById";
+
+// Looks up a committee's display name from an already-loaded (active-only)
+// committee list, without requiring a network round trip for the common case.
+export function getCommitteeDisplayName(knownCommittees, resolvedNames, committeeId) {
+  if (!committeeId) return null;
+  const committee = knownCommittees.find(
+    (c) => c.id === committeeId || String(c._id) === committeeId,
+  );
+  if (committee) return committee.displayName;
+  return resolvedNames[committeeId] ?? null;
+}
+
+// Committee lists elsewhere in the app are filtered to isActive:true, so a
+// committee that's since been closed drops out of them. A member's existing
+// selections/applications can still reference one, though, so this fetches
+// those specific committees by ID (GET /committees/:id has no active-only
+// filter) and caches the resolved names.
+export default function useResolvedCommitteeNames(committeeIds, knownCommittees) {
+  const [resolvedNames, setResolvedNames] = useState({});
+  const idsKey = committeeIds.filter(Boolean).join(",");
+  const knownKey = knownCommittees.map((c) => c.id ?? c._id).join(",");
+
+  useEffect(() => {
+    const missingIds = committeeIds.filter((id) => (
+      id
+      && !knownCommittees.some((c) => c.id === id || String(c._id) === id)
+      && !(id in resolvedNames)
+    ));
+    if (missingIds.length === 0) return undefined;
+
+    let cancelled = false;
+    (async () => {
+      const entries = await Promise.all(
+        missingIds.map(async (id) => {
+          const result = await fetchCommitteeById(id);
+          return [id, result.success ? result.data.displayName : id];
+        }),
+      );
+      if (cancelled) return;
+      setResolvedNames((prev) => ({ ...prev, ...Object.fromEntries(entries) }));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, knownKey]);
+
+  return resolvedNames;
+}

--- a/lib/types/Internship.ts
+++ b/lib/types/Internship.ts
@@ -64,7 +64,6 @@ export interface InternshipCommittee {
   name: string;
   displayName: string;
   description?: string;
-  subcommittees: string[];
   isActive: boolean;
   internLimit?: number;
   applicationDeadline?: string;
@@ -105,7 +104,6 @@ export type CreateInternshipCommitteePayload = {
   name: string;
   displayName: string;
   description?: string;
-  subcommittees?: string[];
   isActive?: boolean;
   internLimit?: number;
   applicationDeadline?: string | Date;
@@ -114,4 +112,55 @@ export type CreateInternshipCommitteePayload = {
 
 export type CreateInternshipCommitteeResult =
   | { success: true; data: InternshipCommittee }
+  | { success: false; error: string };
+
+export type UpdateInternshipCommitteePayload = Partial<CreateInternshipCommitteePayload>;
+
+export type UpdateInternshipCommitteeResult =
+  | { success: true; data: InternshipCommittee }
+  | { success: false; error: string };
+
+export type DeleteInternshipCommitteeResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type ArchiveCommitteeResult =
+  | { success: true; archivedCount: number }
+  | { success: false; error: string };
+
+export interface InternshipCycleInfo {
+  currentCycle: string;
+  suggestedNextCycle: string;
+  pastCycles: string[];
+}
+
+export type FetchCycleInfoResult =
+  | { success: true; data: InternshipCycleInfo }
+  | { success: false; error: string };
+
+export type AdvanceCycleResult =
+  | { success: true; previousCycle: string; newCycle: string; archivedCount: number }
+  | { success: false; error: string };
+
+export interface FetchApplicationsOptions {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: string;
+  committeeId?: string;
+  choiceRank?: "1" | "2" | "3";
+  applicationCycle?: string;
+  archived?: boolean;
+  includeDrafts?: boolean;
+}
+
+export interface InternshipApplicationsPagination {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+}
+
+export type InternshipApplicationsListResult =
+  | { success: true; data: InternshipApplication[]; pagination: InternshipApplicationsPagination }
   | { success: false; error: string };


### PR DESCRIPTION
## Description
                                            
- Adds application-cycle tracking (InternshipSettings, cycleController) so admins can view the current/past cycle and advance to a new one, archiving the outgoing cycle's applications per committee.                                      - Adds committee ad/archive) as alighter-weight alternative to deactivation — clears current-cycle appl committee documentitself.
- Adds a per-status application count endpoint (GET /applications/statin dashboards canshow counts without paginating through all applications.
- Frontend: officer and admin dashboards get real cycle/status-count data, a new CommitteeForm for creating/editing committees, and matching server actions (advanceApplicationCycle, archiveCommittee, tionCycle,fetchApplicationStatusCounts, updateCommittee).

## Frontend Specific
- New: CommitteeForm.jsx, cycle/committee/status-count server actions
- Changed: OfficerDashboard, AdminDashboard, CommitteeTable, ApplicationTable, committee edit/new pages, CopyEmailsButton, shared types/config

## Related Issue

Resolves # (issue)

## Steps to view & test changes:
- [ ] npm test in both repos
- [ ] Advance a cycle as admin, confirm outgoing applications archive correctly
- [ ] Archive a single committee, confirm its applications clear without deactivating the committee
- [ ] Officer dashboard status counts match actual application data
- [ ] Create/edit a committee via the new CommitteeForm
- 

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots (if appropriate)
